### PR TITLE
Implement tick-based battle scale prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .godot/
 tools/godot/
+logs/

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ From the project root:
 
 - macOS/Linux (bash/zsh): `./run.sh`
 - Windows (PowerShell): `.\run.ps1`
+
+Headless resolve (no rendering):
+- `./run.sh --headless --resolve-only`
+- `.\run.ps1 --resolve-only`

--- a/resolver/battle_resolver.gd
+++ b/resolver/battle_resolver.gd
@@ -1,0 +1,711 @@
+class_name BattleResolver
+extends Object
+
+const BattleConstants = preload("res://schema/constants.gd")
+const XorShift32 = preload("res://schema/prng.gd")
+const EventLog = preload("res://schema/event_log.gd")
+const BattleResult = preload("res://schema/battle_result.gd")
+
+const INF_DISTANCE = 1_000_000
+const STALL_TICK_LIMIT = 0
+
+static func resolve(input) -> Dictionary:
+	var start_ms = Time.get_ticks_msec()
+	var rng = XorShift32.new(input.seed)
+	var event_log = EventLog.new()
+
+	var width = input.grid_width
+	var height = input.grid_height
+	var tile_count = width * height
+	var unit_count = input.unit_count()
+
+	event_log.add_event(
+		0,
+		0,
+		BattleConstants.EventType.BATTLE_INIT,
+		width,
+		height,
+		input.time_limit_ticks,
+		unit_count
+	)
+
+	var alive = PackedInt32Array()
+	alive.resize(unit_count)
+	for i in range(unit_count):
+		alive[i] = 1
+
+	var side = input.unit_sides.duplicate()
+	var unit_type = input.unit_types.duplicate()
+	var unit_size = input.unit_sizes.duplicate()
+	var unit_x = input.unit_x.duplicate()
+	var unit_y = input.unit_y.duplicate()
+	var next_tick = input.unit_next_tick.duplicate()
+	if next_tick.size() < unit_count:
+		next_tick.resize(unit_count)
+		for i in range(unit_count):
+			next_tick[i] = 0
+
+	var tile_side = PackedInt32Array()
+	tile_side.resize(tile_count)
+	var tile_unit_count = PackedInt32Array()
+	tile_unit_count.resize(tile_count)
+	var tile_total_size = PackedInt32Array()
+	tile_total_size.resize(tile_count)
+	var tile_units = []
+	tile_units.resize(tile_count)
+	for i in range(tile_count):
+		tile_side[i] = -1
+		tile_unit_count[i] = 0
+		tile_total_size[i] = 0
+		tile_units[i] = []
+
+	for id in range(unit_count):
+		var tile = unit_x[id] + unit_y[id] * width
+		_add_unit_to_tile(tile, id, side[id], unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+		event_log.add_event(
+			0,
+			id,
+			BattleConstants.EventType.UNIT_SPAWNED,
+			id,
+			side[id],
+			unit_type[id],
+			BattleConstants.encode_pos(unit_x[id], unit_y[id])
+		)
+
+	var neighbors = _build_neighbors(width, height)
+
+	var projectiles_by_tick = []
+	projectiles_by_tick.resize(input.time_limit_ticks + 1)
+	for i in range(projectiles_by_tick.size()):
+		projectiles_by_tick[i] = []
+
+	var projectile_type = PackedInt32Array()
+	var projectile_target_tile = PackedInt32Array()
+	var projectile_shooter_id = PackedInt32Array()
+	var projectile_impact_tick = PackedInt32Array()
+	var next_projectile_id = 0
+
+	var units_remaining = PackedInt32Array([0, 0])
+	for id in range(unit_count):
+		units_remaining[side[id]] += 1
+
+	var ticks_elapsed = 0
+	var stall_ticks = 0
+
+	for tick in range(input.time_limit_ticks + 1):
+		ticks_elapsed = tick
+		var activity = false
+
+		var impacts = projectiles_by_tick[tick]
+		if impacts.size() > 0:
+			activity = true
+		for pid in impacts:
+			var p_type = projectile_type[pid]
+			var target_tile = projectile_target_tile[pid]
+			event_log.add_event(
+				tick,
+				0,
+				BattleConstants.EventType.PROJECTILE_IMPACTED,
+				pid,
+				p_type,
+				target_tile,
+				0
+			)
+			var shooter_id = projectile_shooter_id[pid]
+			var shooter_side = side[shooter_id]
+			var enemy_side = BattleConstants.enemy_side(shooter_side)
+			if tile_side[target_tile] == enemy_side:
+				if p_type == BattleConstants.ProjectileType.ARROW:
+					var target_id = _pick_random_unit(tile_units[target_tile], rng)
+					if target_id != -1:
+						_remove_unit(
+							target_id,
+							tick,
+							0,
+							BattleConstants.EventType.UNIT_REMOVED,
+							1,
+							shooter_id,
+							width,
+							side,
+							unit_size,
+							unit_x,
+							unit_y,
+							alive,
+							units_remaining,
+							tile_side,
+							tile_unit_count,
+							tile_total_size,
+							tile_units,
+							event_log
+						)
+						activity = true
+				else:
+					var removed_any = false
+					var targets = tile_units[target_tile].duplicate()
+					for target_id in targets:
+						if side[target_id] == enemy_side and alive[target_id] == 1:
+							_remove_unit(
+								target_id,
+								tick,
+								0,
+								BattleConstants.EventType.UNIT_REMOVED,
+								2,
+								shooter_id,
+								width,
+								side,
+								unit_size,
+								unit_x,
+								unit_y,
+								alive,
+								units_remaining,
+								tile_side,
+								tile_unit_count,
+								tile_total_size,
+								tile_units,
+								event_log
+							)
+							removed_any = true
+					if removed_any:
+						activity = true
+
+		if units_remaining[BattleConstants.Side.RED] == 0 or units_remaining[BattleConstants.Side.BLUE] == 0:
+			break
+
+		var dist_red_size2 = _compute_distance_field(
+			width,
+			height,
+			BattleConstants.Side.RED,
+			2,
+			tile_side,
+			tile_unit_count,
+			tile_total_size,
+			input.max_units_per_tile,
+			input.max_total_size_per_tile,
+			neighbors
+		)
+		var dist_red_size3 = _compute_distance_field(
+			width,
+			height,
+			BattleConstants.Side.RED,
+			3,
+			tile_side,
+			tile_unit_count,
+			tile_total_size,
+			input.max_units_per_tile,
+			input.max_total_size_per_tile,
+			neighbors
+		)
+		var dist_blue_size2 = _compute_distance_field(
+			width,
+			height,
+			BattleConstants.Side.BLUE,
+			2,
+			tile_side,
+			tile_unit_count,
+			tile_total_size,
+			input.max_units_per_tile,
+			input.max_total_size_per_tile,
+			neighbors
+		)
+		var dist_blue_size3 = _compute_distance_field(
+			width,
+			height,
+			BattleConstants.Side.BLUE,
+			3,
+			tile_side,
+			tile_unit_count,
+			tile_total_size,
+			input.max_units_per_tile,
+			input.max_total_size_per_tile,
+			neighbors
+		)
+
+		for id in range(unit_count):
+			if alive[id] == 0:
+				continue
+			if next_tick[id] > tick:
+				continue
+
+			var u_type = unit_type[id]
+			var u_side = side[id]
+			var ux = unit_x[id]
+			var uy = unit_y[id]
+			var enemy_side = BattleConstants.enemy_side(u_side)
+
+			var current_tile = ux + uy * width
+			var target_tile = _find_adjacent_enemy(current_tile, enemy_side, tile_side, neighbors)
+			var acted = false
+
+			if _is_melee_unit(u_type) and target_tile != -1:
+				var hit_roll = rng.next_range(100)
+				var hit_chance = BattleConstants.MELEE_HIT_CHANCE[u_type]
+				var hit = hit_roll < hit_chance
+				event_log.add_event(
+					tick,
+					id,
+					BattleConstants.EventType.MELEE_ATTACK_RESOLVED,
+					id,
+					target_tile,
+					1 if hit else 0,
+					0
+				)
+				if hit:
+					var target_id = _pick_random_unit(tile_units[target_tile], rng)
+					if target_id != -1:
+						_remove_unit(
+							target_id,
+							tick,
+							id,
+							BattleConstants.EventType.UNIT_REMOVED,
+							0,
+							id,
+							width,
+							side,
+							unit_size,
+							unit_x,
+							unit_y,
+							alive,
+							units_remaining,
+							tile_side,
+							tile_unit_count,
+							tile_total_size,
+							tile_units,
+							event_log
+						)
+						activity = true
+				acted = true
+				next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
+				continue
+
+			if _is_archer(u_type):
+				var range = BattleConstants.RANGED_RANGE[u_type]
+				var ranged_tile = _find_nearest_enemy_in_range(ux, uy, range, enemy_side, tile_side, width, height)
+				if ranged_tile != -1:
+					var pid = next_projectile_id
+					next_projectile_id += 1
+					_schedule_projectile(
+						pid,
+						BattleConstants.ProjectileType.ARROW,
+						ranged_tile,
+						id,
+						tick,
+						width,
+						unit_x,
+						unit_y,
+						projectiles_by_tick,
+						projectile_type,
+						projectile_target_tile,
+						projectile_shooter_id,
+						projectile_impact_tick
+					)
+					event_log.add_event(
+						tick,
+						id,
+						BattleConstants.EventType.PROJECTILE_FIRED,
+						pid,
+						BattleConstants.ProjectileType.ARROW,
+						id,
+						BattleConstants.encode_pos(ranged_tile % width, int(ranged_tile / width))
+					)
+					activity = true
+					acted = true
+					next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
+					continue
+
+			if _is_mage(u_type):
+				var mage_range = BattleConstants.RANGED_RANGE[u_type]
+				var fire_tile = _find_best_fireball_tile(ux, uy, mage_range, enemy_side, tile_side, tile_unit_count, width, height)
+				if fire_tile != -1:
+					var pid2 = next_projectile_id
+					next_projectile_id += 1
+					_schedule_projectile(
+						pid2,
+						BattleConstants.ProjectileType.FIREBALL,
+						fire_tile,
+						id,
+						tick,
+						width,
+						unit_x,
+						unit_y,
+						projectiles_by_tick,
+						projectile_type,
+						projectile_target_tile,
+						projectile_shooter_id,
+						projectile_impact_tick
+					)
+					event_log.add_event(
+						tick,
+						id,
+						BattleConstants.EventType.PROJECTILE_FIRED,
+						pid2,
+						BattleConstants.ProjectileType.FIREBALL,
+						id,
+						BattleConstants.encode_pos(fire_tile % width, int(fire_tile / width))
+					)
+					activity = true
+					acted = true
+					next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
+					continue
+
+			if not acted:
+				var dist_field = dist_red_size2
+				if u_side == BattleConstants.Side.RED:
+					dist_field = dist_red_size3 if unit_size[id] == 3 else dist_red_size2
+				else:
+					dist_field = dist_blue_size3 if unit_size[id] == 3 else dist_blue_size2
+
+				var best_tile = _choose_move_tile(
+					current_tile,
+					u_side,
+					unit_size[id],
+					dist_field,
+					tile_side,
+					tile_unit_count,
+					tile_total_size,
+					input.max_units_per_tile,
+					input.max_total_size_per_tile,
+					neighbors
+				)
+				if best_tile != -1:
+					var from_pos = BattleConstants.encode_pos(ux, uy)
+					var new_x = best_tile % width
+					var new_y = best_tile / width
+					_remove_unit_from_tile(current_tile, id, unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+					_add_unit_to_tile(best_tile, id, u_side, unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+					unit_x[id] = new_x
+					unit_y[id] = new_y
+					event_log.add_event(
+						tick,
+						id,
+						BattleConstants.EventType.UNIT_MOVED,
+						id,
+						from_pos,
+						BattleConstants.encode_pos(new_x, new_y),
+						0
+					)
+					activity = true
+					next_tick[id] = tick + BattleConstants.MOVE_COST[u_type]
+				else:
+					next_tick[id] = tick + BattleConstants.WAIT_COST[u_type]
+
+		if units_remaining[BattleConstants.Side.RED] == 0 or units_remaining[BattleConstants.Side.BLUE] == 0:
+			break
+
+		if activity:
+			stall_ticks = 0
+		else:
+			stall_ticks += 1
+			if STALL_TICK_LIMIT > 0 and stall_ticks >= STALL_TICK_LIMIT:
+				break
+
+	var winner = -1
+	if units_remaining[BattleConstants.Side.RED] == 0 and units_remaining[BattleConstants.Side.BLUE] == 0:
+		winner = -1
+	elif units_remaining[BattleConstants.Side.RED] == 0:
+		winner = BattleConstants.Side.BLUE
+	elif units_remaining[BattleConstants.Side.BLUE] == 0:
+		winner = BattleConstants.Side.RED
+	else:
+		winner = -1
+
+	var result = BattleResult.new()
+	result.winner = winner
+	result.ticks_elapsed = ticks_elapsed
+	result.units_remaining_by_side = units_remaining
+	result.resolve_ms = Time.get_ticks_msec() - start_ms
+	if result.resolve_ms > 0:
+		result.avg_ticks_per_sec = (float(ticks_elapsed) / (float(result.resolve_ms) / 1000.0))
+
+	event_log.add_event(
+		ticks_elapsed,
+		0,
+		BattleConstants.EventType.BATTLE_ENDED,
+		winner,
+		ticks_elapsed,
+		units_remaining[BattleConstants.Side.RED],
+		units_remaining[BattleConstants.Side.BLUE]
+	)
+	result.event_count = event_log.count()
+	result.event_hash = event_log.hash_u32()
+
+	return {
+		"event_log": event_log,
+		"result": result,
+	}
+
+static func _build_neighbors(width: int, height: int) -> Array:
+	var neighbors = []
+	neighbors.resize(width * height)
+	for y in range(height):
+		for x in range(width):
+			var list = PackedInt32Array()
+			for dir in BattleConstants.NEIGHBOR_DIRS:
+				var nx = x + dir.x
+				var ny = y + dir.y
+				if nx >= 0 and nx < width and ny >= 0 and ny < height:
+					list.append(nx + ny * width)
+			neighbors[x + y * width] = list
+	return neighbors
+
+static func _is_melee_unit(u_type: int) -> bool:
+	return u_type == BattleConstants.UnitType.INFANTRY \
+		or u_type == BattleConstants.UnitType.HEAVY_INFANTRY \
+		or u_type == BattleConstants.UnitType.ELITE_INFANTRY \
+		or u_type == BattleConstants.UnitType.CAVALRY \
+		or u_type == BattleConstants.UnitType.HEAVY_CAVALRY
+
+static func _is_archer(u_type: int) -> bool:
+	return u_type == BattleConstants.UnitType.ARCHER
+
+static func _is_mage(u_type: int) -> bool:
+	return u_type == BattleConstants.UnitType.MAGE
+
+static func _add_unit_to_tile(
+		tile: int,
+		unit_id: int,
+		unit_side: int,
+		unit_size: int,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		tile_units: Array
+	) -> void:
+	if tile_side[tile] == -1:
+		tile_side[tile] = unit_side
+	tile_units[tile].append(unit_id)
+	tile_unit_count[tile] += 1
+	tile_total_size[tile] += unit_size
+
+static func _remove_unit_from_tile(
+		tile: int,
+		unit_id: int,
+		unit_size: int,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		tile_units: Array
+	) -> void:
+	tile_units[tile].erase(unit_id)
+	tile_unit_count[tile] -= 1
+	tile_total_size[tile] -= unit_size
+	if tile_unit_count[tile] <= 0:
+		tile_side[tile] = -1
+
+static func _tile_can_accept(
+		tile: int,
+		unit_side: int,
+		unit_size: int,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		max_units: int,
+		max_total_size: int
+	) -> bool:
+	var side_value = tile_side[tile]
+	if side_value == -1 or side_value == unit_side:
+		if tile_unit_count[tile] + 1 <= max_units and tile_total_size[tile] + unit_size <= max_total_size:
+			return true
+	return false
+
+static func _find_adjacent_enemy(
+		tile: int,
+		enemy_side: int,
+		tile_side: PackedInt32Array,
+		neighbors: Array
+	) -> int:
+	for neighbor in neighbors[tile]:
+		if tile_side[neighbor] == enemy_side:
+			return neighbor
+	return -1
+
+static func _find_nearest_enemy_in_range(
+		x: int,
+		y: int,
+		range: int,
+		enemy_side: int,
+		tile_side: PackedInt32Array,
+		width: int,
+		height: int
+	) -> int:
+	var best_tile = -1
+	var best_dist = INF_DISTANCE
+	for dy in range(-range, range + 1):
+		var ny = y + dy
+		if ny < 0 or ny >= height:
+			continue
+		var max_dx = range - abs(dy)
+		for dx in range(-max_dx, max_dx + 1):
+			if dx == 0 and dy == 0:
+				continue
+			var nx = x + dx
+			if nx < 0 or nx >= width:
+				continue
+			var tile = nx + ny * width
+			if tile_side[tile] == enemy_side:
+				var dist = abs(dx) + abs(dy)
+				if dist < best_dist or (dist == best_dist and tile < best_tile):
+					best_tile = tile
+					best_dist = dist
+	return best_tile
+
+static func _find_best_fireball_tile(
+		x: int,
+		y: int,
+		range: int,
+		enemy_side: int,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		width: int,
+		height: int
+	) -> int:
+	var best_tile = -1
+	var best_count = -1
+	for dy in range(-range, range + 1):
+		var ny = y + dy
+		if ny < 0 or ny >= height:
+			continue
+		var max_dx = range - abs(dy)
+		for dx in range(-max_dx, max_dx + 1):
+			if dx == 0 and dy == 0:
+				continue
+			var nx = x + dx
+			if nx < 0 or nx >= width:
+				continue
+			var tile = nx + ny * width
+			if tile_side[tile] == enemy_side:
+				var count = tile_unit_count[tile]
+				if count > best_count or (count == best_count and tile < best_tile):
+					best_tile = tile
+					best_count = count
+	return best_tile
+
+static func _compute_distance_field(
+		width: int,
+		height: int,
+		unit_side: int,
+		unit_size: int,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		max_units: int,
+		max_total_size: int,
+		neighbors: Array
+	) -> PackedInt32Array:
+	var tile_count = width * height
+	var dist = PackedInt32Array()
+	dist.resize(tile_count)
+	for i in range(tile_count):
+		dist[i] = INF_DISTANCE
+
+	var queue = PackedInt32Array()
+	var head = 0
+	for tile in range(tile_count):
+		if tile_side[tile] != -1 and tile_side[tile] != unit_side:
+			dist[tile] = 0
+			queue.append(tile)
+
+	while head < queue.size():
+		var tile = queue[head]
+		head += 1
+		var next_dist = dist[tile] + 1
+		for neighbor in neighbors[tile]:
+			if dist[neighbor] <= next_dist:
+				continue
+			if _tile_can_accept(neighbor, unit_side, unit_size, tile_side, tile_unit_count, tile_total_size, max_units, max_total_size):
+				dist[neighbor] = next_dist
+				queue.append(neighbor)
+	return dist
+
+static func _choose_move_tile(
+		current_tile: int,
+		unit_side: int,
+		unit_size: int,
+		dist_field: PackedInt32Array,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		max_units: int,
+		max_total_size: int,
+		neighbors: Array
+	) -> int:
+	var best_tile = -1
+	var best_dist = INF_DISTANCE
+	var current_dist = dist_field[current_tile]
+	for neighbor in neighbors[current_tile]:
+		var dist = dist_field[neighbor]
+		if dist < best_dist and dist < current_dist and _tile_can_accept(neighbor, unit_side, unit_size, tile_side, tile_unit_count, tile_total_size, max_units, max_total_size):
+			best_dist = dist
+			best_tile = neighbor
+	return best_tile
+
+static func _schedule_projectile(
+		pid: int,
+		p_type: int,
+		target_tile: int,
+		shooter_id: int,
+		tick: int,
+		width: int,
+		unit_x: PackedInt32Array,
+		unit_y: PackedInt32Array,
+		projectiles_by_tick: Array,
+		projectile_type: PackedInt32Array,
+		projectile_target_tile: PackedInt32Array,
+		projectile_shooter_id: PackedInt32Array,
+		projectile_impact_tick: PackedInt32Array
+	) -> int:
+	var sx = unit_x[shooter_id]
+	var sy = unit_y[shooter_id]
+	var tx = target_tile % width
+	var ty = target_tile / width
+	var distance = abs(tx - sx) + abs(ty - sy)
+	var speed = BattleConstants.PROJECTILE_SPEED[p_type]
+	var impact_tick = tick + (speed * distance)
+	projectile_type.append(p_type)
+	projectile_target_tile.append(target_tile)
+	projectile_shooter_id.append(shooter_id)
+	projectile_impact_tick.append(impact_tick)
+	if impact_tick >= 0 and impact_tick < projectiles_by_tick.size():
+		projectiles_by_tick[impact_tick].append(pid)
+	return impact_tick
+
+static func _pick_random_unit(tile_list: Array, rng) -> int:
+	if tile_list.is_empty():
+		return -1
+	var index = rng.next_range(tile_list.size())
+	return tile_list[index]
+
+static func _remove_unit(
+		unit_id: int,
+		tick: int,
+		seq: int,
+		event_type: int,
+		reason: int,
+		source_id: int,
+		width: int,
+		side: PackedInt32Array,
+		unit_size: PackedInt32Array,
+		unit_x: PackedInt32Array,
+		unit_y: PackedInt32Array,
+		alive: PackedInt32Array,
+		units_remaining: PackedInt32Array,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		tile_units: Array,
+		event_log
+	) -> void:
+	if alive[unit_id] == 0:
+		return
+	alive[unit_id] = 0
+	units_remaining[side[unit_id]] -= 1
+	var tile_index = unit_x[unit_id] + unit_y[unit_id] * width
+	_remove_unit_from_tile(tile_index, unit_id, unit_size[unit_id], tile_side, tile_unit_count, tile_total_size, tile_units)
+	event_log.add_event(
+		tick,
+		seq,
+		event_type,
+		unit_id,
+		reason,
+		source_id,
+		BattleConstants.encode_pos(unit_x[unit_id], unit_y[unit_id])
+	)

--- a/scenarios/scale_test_v1.gd
+++ b/scenarios/scale_test_v1.gd
@@ -1,0 +1,128 @@
+class_name ScaleTestV1
+extends Object
+
+const BattleConstants = preload("res://schema/constants.gd")
+const BattleInput = preload("res://schema/battle_input.gd")
+
+const GRID_WIDTH = 42
+const GRID_HEIGHT = 20
+const DEPLOY_WIDTH = 15
+const DEPLOY_HEIGHT = 20
+const RED_ZONE_START = 0
+const BLUE_ZONE_START = 27
+
+const MAX_UNITS_PER_TILE = 4
+const MAX_TOTAL_SIZE_PER_TILE = 10
+const TIME_LIMIT_TICKS = 5000
+
+const DEFAULT_SEED = 12345
+
+static func build(seed: int = DEFAULT_SEED):
+	var input = BattleInput.new()
+	input.grid_width = GRID_WIDTH
+	input.grid_height = GRID_HEIGHT
+	input.max_units_per_tile = MAX_UNITS_PER_TILE
+	input.max_total_size_per_tile = MAX_TOTAL_SIZE_PER_TILE
+	input.seed = seed
+	input.time_limit_ticks = TIME_LIMIT_TICKS
+
+	var next_id = 0
+	next_id = _populate_side(input, BattleConstants.Side.RED, RED_ZONE_START, next_id)
+	next_id = _populate_side(input, BattleConstants.Side.BLUE, BLUE_ZONE_START, next_id)
+	return input
+
+static func _populate_side(input, side: int, zone_start: int, next_id: int) -> int:
+	var front_is_high = side == BattleConstants.Side.RED
+
+	var flank_front_cols = []
+	var flank_back_cols = []
+	if front_is_high:
+		flank_front_cols = [zone_start + 12, zone_start + 13, zone_start + 14]
+		flank_back_cols = [zone_start + 0, zone_start + 1, zone_start + 2]
+	else:
+		flank_front_cols = [zone_start + 0, zone_start + 1, zone_start + 2]
+		flank_back_cols = [zone_start + 12, zone_start + 13, zone_start + 14]
+
+	var center_cols = []
+	for x in range(zone_start + 3, zone_start + 12):
+		center_cols.append(x)
+
+	var flank_positions = []
+	flank_positions.append_array(_positions_from_columns(_order_columns(flank_front_cols, front_is_high), 3))
+	flank_positions.append_array(_positions_from_columns(_order_columns(flank_back_cols, front_is_high), 3))
+
+	var center_positions = _positions_from_columns(_order_columns(center_cols, front_is_high), 4)
+
+	var flank_index = 0
+	var center_index = 0
+
+	var result = _add_units(input, side, BattleConstants.UnitType.CAVALRY, 150, flank_positions, flank_index, next_id)
+	flank_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.HEAVY_CAVALRY, 150, flank_positions, flank_index, next_id)
+	flank_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.HEAVY_INFANTRY, 150, center_positions, center_index, next_id)
+	center_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.INFANTRY, 150, center_positions, center_index, next_id)
+	center_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.ELITE_INFANTRY, 150, center_positions, center_index, next_id)
+	center_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.ARCHER, 200, center_positions, center_index, next_id)
+	center_index = result.pos_index
+	next_id = result.next_id
+
+	result = _add_units(input, side, BattleConstants.UnitType.MAGE, 50, center_positions, center_index, next_id)
+	center_index = result.pos_index
+	next_id = result.next_id
+
+	return next_id
+
+static func _order_columns(columns: Array, front_is_high: bool) -> Array:
+	var ordered = columns.duplicate()
+	ordered.sort()
+	if front_is_high:
+		ordered.reverse()
+	return ordered
+
+static func _positions_from_columns(columns: Array, slots_per_tile: int) -> Array:
+	var positions = []
+	for x in columns:
+		for y in range(DEPLOY_HEIGHT):
+			for slot in range(slots_per_tile):
+				positions.append(Vector2i(x, y))
+	return positions
+
+static func _add_units(
+		input,
+		side: int,
+		unit_type: int,
+		count: int,
+		positions: Array,
+		pos_index: int,
+		next_id: int
+	) -> Dictionary:
+	var unit_size = BattleConstants.UNIT_SIZE[unit_type]
+	for i in range(count):
+		var pos: Vector2i = positions[pos_index]
+		pos_index += 1
+		input.unit_ids.append(next_id)
+		input.unit_sides.append(side)
+		input.unit_types.append(unit_type)
+		input.unit_sizes.append(unit_size)
+		input.unit_x.append(pos.x)
+		input.unit_y.append(pos.y)
+		input.unit_next_tick.append(0)
+		next_id += 1
+	return {
+		"pos_index": pos_index,
+		"next_id": next_id,
+	}

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -1,5 +1,132 @@
 extends Node2D
 
+const BattleConstants = preload("res://schema/constants.gd")
+const BattleResolver = preload("res://resolver/battle_resolver.gd")
+const BattleReplayer = preload("res://replayer/battle_replayer.gd")
+const BattleView = preload("res://replayer/battle_view.gd")
+const BattleUI = preload("res://ui/battle_ui.gd")
+const ScaleTestV1 = preload("res://scenarios/scale_test_v1.gd")
+
+const DEFAULT_TPS = 20
+
+var _battle_view
+var _battle_ui
+var _replayer
+var _resolver_thread: Thread
+var _resolving: bool = false
+var _last_result
+var _last_event_log
+var _current_tps: int = DEFAULT_TPS
+
 func _ready() -> void:
-	# Print to stdout to confirm headless launch.
-	print("Godot skeleton loaded")
+	var args = OS.get_cmdline_args()
+	if "--resolve-only" in args:
+		_run_headless_resolve()
+		return
+
+	_battle_view = BattleView.new()
+	add_child(_battle_view)
+
+	_battle_ui = BattleUI.new()
+	add_child(_battle_ui)
+	_battle_ui.resolve_requested.connect(_start_resolve)
+	_battle_ui.play_toggled.connect(_on_play_toggled)
+	_battle_ui.step_requested.connect(_on_step_requested)
+	_battle_ui.speed_changed.connect(_on_speed_changed)
+
+	_start_resolve()
+
+func _process(delta: float) -> void:
+	if _resolving and _resolver_thread != null and not _resolver_thread.is_alive():
+		var result = _resolver_thread.wait_to_finish()
+		_resolving = false
+		_battle_ui.set_resolving(false)
+		_on_resolve_complete(result)
+
+	if _replayer != null and not _resolving:
+		_replayer.update(delta)
+		_battle_view.render(_replayer)
+
+	_update_debug_overlay()
+
+func _start_resolve() -> void:
+	if _resolving:
+		return
+	_resolving = true
+	_battle_ui.set_resolving(true)
+	_battle_ui.set_playing(false)
+	_replayer = null
+	_last_event_log = null
+	_last_result = null
+
+	_resolver_thread = Thread.new()
+	_resolver_thread.start(Callable(self, "_resolve_task"))
+
+func _resolve_task() -> Dictionary:
+	var input = ScaleTestV1.build()
+	return BattleResolver.resolve(input)
+
+func _on_resolve_complete(result: Dictionary) -> void:
+	_last_event_log = result.get("event_log", null)
+	_last_result = result.get("result", null)
+	if _last_event_log == null:
+		return
+	_replayer = BattleReplayer.new()
+	_replayer.initialize_from_log(_last_event_log)
+	_replayer.set_ticks_per_second(_current_tps)
+	_replayer.set_playing(true)
+	_battle_ui.set_playing(true)
+
+func _on_play_toggled(playing: bool) -> void:
+	if _replayer == null:
+		return
+	_replayer.set_playing(playing)
+
+func _on_step_requested() -> void:
+	if _replayer == null:
+		return
+	_replayer.step_tick()
+
+func _on_speed_changed(tps: int) -> void:
+	_current_tps = tps
+	if _replayer != null:
+		_replayer.set_ticks_per_second(tps)
+
+func _update_debug_overlay() -> void:
+	if _battle_ui == null:
+		return
+	var lines = []
+	lines.append("FPS: %d" % Engine.get_frames_per_second())
+	if _replayer != null:
+		lines.append("Tick: %d" % _replayer.current_tick)
+		lines.append("Alive: R %d / B %d" % [_replayer.units_remaining[BattleConstants.Side.RED], _replayer.units_remaining[BattleConstants.Side.BLUE]])
+	if _last_event_log != null:
+		lines.append("Events: %d" % _last_event_log.count())
+	if _last_result != null:
+		lines.append("Resolve: %d ms (%.1f tps)" % [_last_result.resolve_ms, _last_result.avg_ticks_per_sec])
+		lines.append("Log hash: %08x" % _last_result.event_hash)
+		lines.append("Winner: %s" % _winner_name(_last_result.winner))
+	if _resolving:
+		lines.append("Resolving...")
+	_battle_ui.set_debug_text("\n".join(lines))
+
+func _winner_name(winner: int) -> String:
+	if winner == BattleConstants.Side.RED:
+		return "Red"
+	if winner == BattleConstants.Side.BLUE:
+		return "Blue"
+	return "Draw"
+
+func _run_headless_resolve() -> void:
+	var input = ScaleTestV1.build()
+	var result = BattleResolver.resolve(input)
+	var battle_result = result.get("result", null)
+	if battle_result != null:
+		print("Resolved ticks: %d" % battle_result.ticks_elapsed)
+		print("Winner: %s" % _winner_name(battle_result.winner))
+		print("Units remaining: R %d / B %d" % [battle_result.units_remaining_by_side[BattleConstants.Side.RED], battle_result.units_remaining_by_side[BattleConstants.Side.BLUE]])
+		print("Resolve ms: %d" % battle_result.resolve_ms)
+		print("Avg ticks/sec: %.2f" % battle_result.avg_ticks_per_sec)
+		print("Event count: %d" % battle_result.event_count)
+		print("Event hash: %08x" % battle_result.event_hash)
+	get_tree().quit()

--- a/schema/battle_input.gd
+++ b/schema/battle_input.gd
@@ -1,0 +1,20 @@
+class_name BattleInput
+extends Object
+
+var grid_width: int
+var grid_height: int
+var max_units_per_tile: int
+var max_total_size_per_tile: int
+var seed: int
+var time_limit_ticks: int
+
+var unit_ids = PackedInt32Array()
+var unit_sides = PackedInt32Array()
+var unit_types = PackedInt32Array()
+var unit_sizes = PackedInt32Array()
+var unit_x = PackedInt32Array()
+var unit_y = PackedInt32Array()
+var unit_next_tick = PackedInt32Array()
+
+func unit_count() -> int:
+	return unit_ids.size()

--- a/schema/battle_result.gd
+++ b/schema/battle_result.gd
@@ -1,0 +1,10 @@
+class_name BattleResult
+extends Object
+
+var winner: int = -1
+var ticks_elapsed: int = 0
+var units_remaining_by_side = PackedInt32Array([0, 0])
+var resolve_ms: int = 0
+var avg_ticks_per_sec: float = 0.0
+var event_count: int = 0
+var event_hash: int = 0

--- a/schema/constants.gd
+++ b/schema/constants.gd
@@ -1,0 +1,69 @@
+class_name BattleConstants
+extends Object
+
+enum Side {
+	RED = 0,
+	BLUE = 1,
+}
+
+enum UnitType {
+	INFANTRY = 0,
+	HEAVY_INFANTRY = 1,
+	ELITE_INFANTRY = 2,
+	ARCHER = 3,
+	CAVALRY = 4,
+	HEAVY_CAVALRY = 5,
+	MAGE = 6,
+}
+
+enum EventType {
+	BATTLE_INIT = 0,
+	UNIT_SPAWNED = 1,
+	UNIT_MOVED = 2,
+	MELEE_ATTACK_RESOLVED = 3,
+	PROJECTILE_FIRED = 4,
+	PROJECTILE_IMPACTED = 5,
+	UNIT_REMOVED = 6,
+	BATTLE_ENDED = 7,
+}
+
+enum ProjectileType {
+	ARROW = 0,
+	FIREBALL = 1,
+}
+
+static var UNIT_SIZE = PackedInt32Array([2, 2, 2, 2, 3, 3, 2])
+static var MOVE_COST = PackedInt32Array([6, 7, 6, 6, 4, 5, 6])
+static var ATTACK_COST = PackedInt32Array([12, 13, 11, 14, 12, 13, 16])
+static var WAIT_COST = PackedInt32Array([1, 1, 1, 1, 1, 1, 1])
+static var MELEE_HIT_CHANCE = PackedInt32Array([50, 55, 60, 0, 50, 55, 0])
+static var RANGED_RANGE = PackedInt32Array([0, 0, 0, 5, 0, 0, 6])
+static var PROJECTILE_SPEED = PackedInt32Array([2, 3])
+
+const NEIGHBOR_DIRS = [
+	Vector2i(0, -1),
+	Vector2i(1, 0),
+	Vector2i(0, 1),
+	Vector2i(-1, 0),
+]
+
+static func enemy_side(side: int) -> int:
+	return Side.BLUE if side == Side.RED else Side.RED
+
+static func encode_pos(x: int, y: int) -> int:
+	return (y << 16) | (x & 0xFFFF)
+
+static func decode_x(pos: int) -> int:
+	return pos & 0xFFFF
+
+static func decode_y(pos: int) -> int:
+	return (pos >> 16) & 0xFFFF
+
+static func tile_index(x: int, y: int, width: int) -> int:
+	return x + y * width
+
+static func index_to_x(index: int, width: int) -> int:
+	return index % width
+
+static func index_to_y(index: int, width: int) -> int:
+	return index / width

--- a/schema/event_log.gd
+++ b/schema/event_log.gd
@@ -1,0 +1,36 @@
+class_name EventLog
+extends Object
+
+var ticks = PackedInt32Array()
+var seqs = PackedInt32Array()
+var types = PackedInt32Array()
+var a = PackedInt32Array()
+var b = PackedInt32Array()
+var c = PackedInt32Array()
+var d = PackedInt32Array()
+
+func add_event(tick: int, seq: int, event_type: int, a_val: int = 0, b_val: int = 0, c_val: int = 0, d_val: int = 0) -> void:
+	ticks.append(tick)
+	seqs.append(seq)
+	types.append(event_type)
+	a.append(a_val)
+	b.append(b_val)
+	c.append(c_val)
+	d.append(d_val)
+
+func count() -> int:
+	return ticks.size()
+
+func hash_u32() -> int:
+	var h: int = 2166136261
+	var size = ticks.size()
+	for i in size:
+		h = (h ^ ticks[i]) * 16777619
+		h = (h ^ seqs[i]) * 16777619
+		h = (h ^ types[i]) * 16777619
+		h = (h ^ a[i]) * 16777619
+		h = (h ^ b[i]) * 16777619
+		h = (h ^ c[i]) * 16777619
+		h = (h ^ d[i]) * 16777619
+		h &= 0xFFFFFFFF
+	return h

--- a/schema/prng.gd
+++ b/schema/prng.gd
@@ -1,0 +1,22 @@
+class_name XorShift32
+extends Object
+
+var _state: int
+
+func _init(seed: int) -> void:
+	_state = seed & 0xFFFFFFFF
+	if _state == 0:
+		_state = 0x6D2B79F5
+
+func next_u32() -> int:
+	var x = _state
+	x = (x ^ ((x << 13) & 0xFFFFFFFF)) & 0xFFFFFFFF
+	x = (x ^ ((x >> 17) & 0xFFFFFFFF)) & 0xFFFFFFFF
+	x = (x ^ ((x << 5) & 0xFFFFFFFF)) & 0xFFFFFFFF
+	_state = x
+	return _state
+
+func next_range(max_exclusive: int) -> int:
+	if max_exclusive <= 0:
+		return 0
+	return int(next_u32() % max_exclusive)

--- a/ui/battle_ui.gd
+++ b/ui/battle_ui.gd
@@ -1,0 +1,87 @@
+class_name BattleUI
+extends CanvasLayer
+
+signal resolve_requested
+signal play_toggled(playing: bool)
+signal step_requested
+signal speed_changed(ticks_per_second: int)
+
+var _resolve_button: Button
+var _play_button: Button
+var _step_button: Button
+var _speed_option: OptionButton
+var _status_label: Label
+var _debug_label: Label
+
+var _playing: bool = true
+
+func _ready() -> void:
+	var panel = PanelContainer.new()
+	panel.position = Vector2(10, 10)
+	add_child(panel)
+
+	var vbox = VBoxContainer.new()
+	panel.add_child(vbox)
+
+	_resolve_button = Button.new()
+	_resolve_button.text = "Resolve"
+	_resolve_button.pressed.connect(_on_resolve_pressed)
+	vbox.add_child(_resolve_button)
+
+	var hbox = HBoxContainer.new()
+	vbox.add_child(hbox)
+
+	_play_button = Button.new()
+	_play_button.text = "Pause"
+	_play_button.pressed.connect(_on_play_pressed)
+	hbox.add_child(_play_button)
+
+	_step_button = Button.new()
+	_step_button.text = "Step"
+	_step_button.pressed.connect(_on_step_pressed)
+	hbox.add_child(_step_button)
+
+	_speed_option = OptionButton.new()
+	_speed_option.add_item("10 tps", 10)
+	_speed_option.add_item("20 tps", 20)
+	_speed_option.add_item("40 tps", 40)
+	_speed_option.select(1)
+	_speed_option.item_selected.connect(_on_speed_selected)
+	vbox.add_child(_speed_option)
+
+	_status_label = Label.new()
+	_status_label.text = ""
+	vbox.add_child(_status_label)
+
+	_debug_label = Label.new()
+	_debug_label.position = Vector2(10, 140)
+	_debug_label.text = ""
+	add_child(_debug_label)
+
+func set_resolving(resolving: bool) -> void:
+	_resolve_button.disabled = resolving
+	_step_button.disabled = resolving
+	_speed_option.disabled = resolving
+	_status_label.text = "Resolving..." if resolving else ""
+
+func set_playing(playing: bool) -> void:
+	_playing = playing
+	_play_button.text = "Pause" if playing else "Play"
+
+func set_debug_text(text: String) -> void:
+	_debug_label.text = text
+
+func _on_resolve_pressed() -> void:
+	emit_signal("resolve_requested")
+
+func _on_play_pressed() -> void:
+	_playing = not _playing
+	set_playing(_playing)
+	emit_signal("play_toggled", _playing)
+
+func _on_step_pressed() -> void:
+	emit_signal("step_requested")
+
+func _on_speed_selected(index: int) -> void:
+	var tps = _speed_option.get_item_id(index)
+	emit_signal("speed_changed", tps)


### PR DESCRIPTION
## Summary
- Implement deterministic resolver + event log, and a replay renderer with minimal UI/overlay
- Add Scale Test v1 scenario generator and headless resolve mode
- Add schema/data contracts + PRNG + replay clock
- Ignore local logs output

## Decisions beyond the docs
- **MultiMesh quads for units/projectiles**: Render as colored `QuadMesh` instances via `MultiMeshInstance2D` to keep draw calls low without needing external art assets.
- **Runtime lookup tables**: Godot doesn't allow `const PackedInt32Array(...)`, so unit size/cost/range tables are `static var` on `BattleConstants` to initialize at runtime.
- **Explicit script preloads**: Use `preload()` for core scripts to avoid `class_name` resolution issues in CLI/headless runs.
- **Avoid type inference shortcuts**: Replaced `:=` with `=` to prevent “cannot infer type” parse errors under strict GDScript parsing.
- **Tinted 1x1 texture**: Generated a 1×1 white texture and tint per unit type to keep sprites lightweight but distinguishable.

## Notes
- Headless resolve: `./run.sh --headless --resolve-only` or `\\.\\run.ps1 --resolve-only`
