### PR TITLE
Add custom army setup with ghost placement

### DIFF
--- a/replayer/battle_view.gd
+++ b/replayer/battle_view.gd
@@ -170,6 +170,9 @@ func render(replayer) -> void:
 		return
 	setup(replayer.grid_width, replayer.grid_height)
 	if replayer.unit_alive.size() == 0:
+		_clear_unit_meshes()
+		_clear_projectile_meshes()
+		_clear_tile_overlay()
 		return
 
 	_update_tile_overlay(replayer)
@@ -233,6 +236,26 @@ func _make_multimesh_instance(texture: Texture2D, color: Color) -> MultiMeshInst
 	instance.texture = texture
 	instance.modulate = color
 	return instance
+
+func _clear_unit_meshes() -> void:
+	_ensure_meshes()
+	for mesh in _unit_meshes:
+		mesh.multimesh.instance_count = 0
+
+func _clear_projectile_meshes() -> void:
+	_ensure_meshes()
+	for mesh in _projectile_meshes:
+		mesh.multimesh.instance_count = 0
+
+func _clear_tile_overlay() -> void:
+	if grid_width <= 0 or grid_height <= 0:
+		return
+	var tile_count = grid_width * grid_height
+	if _tile_side.size() != tile_count:
+		_tile_side.resize(tile_count)
+	for i in range(tile_count):
+		_tile_side[i] = -1
+	queue_redraw()
 
 func _update_unit_meshes(replayer) -> void:
 	var unit_count = replayer.unit_alive.size()

--- a/replayer/battle_view.gd
+++ b/replayer/battle_view.gd
@@ -13,6 +13,8 @@ const UNIT_SCALE = 0.42
 const PROJECTILE_SCALE = 0.2
 const OVERLAY_RED = Color(0.85, 0.2, 0.2, 0.18)
 const OVERLAY_BLUE = Color(0.2, 0.45, 0.9, 0.18)
+const DEPLOY_RED = Color(0.9, 0.25, 0.25, 0.1)
+const DEPLOY_BLUE = Color(0.25, 0.5, 0.95, 0.1)
 const GHOST_ALPHA = 0.35
 const GHOST_INVALID_ALPHA = 0.55
 
@@ -60,6 +62,9 @@ var _projectile_meshes = []
 var _ghost_meshes = []
 var _ghost_units = []
 var _ghost_valid: bool = true
+var _deploy_red_rect: Rect2i = Rect2i()
+var _deploy_blue_rect: Rect2i = Rect2i()
+var _show_deploy_zones: bool = false
 var _zoom: float = VIEW_SCALE
 var _tile_side = PackedInt32Array()
 var _hovered_tile = Vector2i(-1, -1)
@@ -116,6 +121,12 @@ func set_ghost_units(units: Array, valid: bool) -> void:
 	_ghost_valid = valid
 	_update_ghost_meshes()
 
+func set_deployment_zones(red_rect: Rect2i, blue_rect: Rect2i, visible: bool) -> void:
+	_deploy_red_rect = red_rect
+	_deploy_blue_rect = blue_rect
+	_show_deploy_zones = visible
+	queue_redraw()
+
 func _apply_zoom(target_zoom: float, mouse_pos: Vector2) -> void:
 	var clamped = clamp(target_zoom, MIN_ZOOM, MAX_ZOOM)
 	if is_equal_approx(clamped, _zoom):
@@ -139,6 +150,10 @@ func _draw() -> void:
 	var total_width = grid_width * TILE_SIZE
 	var total_height = grid_height * TILE_SIZE
 	draw_rect(Rect2(0, 0, total_width, total_height), Color(0.08, 0.09, 0.12))
+
+	if _show_deploy_zones:
+		_draw_deploy_zone(_deploy_red_rect, DEPLOY_RED)
+		_draw_deploy_zone(_deploy_blue_rect, DEPLOY_BLUE)
 
 	if _tile_side.size() == grid_width * grid_height:
 		for y in range(grid_height):
@@ -164,6 +179,19 @@ func _draw() -> void:
 			false,
 			2.0
 		)
+
+func _draw_deploy_zone(zone: Rect2i, color: Color) -> void:
+	if zone.size.x <= 0 or zone.size.y <= 0:
+		return
+	draw_rect(
+		Rect2(
+			zone.position.x * TILE_SIZE,
+			zone.position.y * TILE_SIZE,
+			zone.size.x * TILE_SIZE,
+			zone.size.y * TILE_SIZE
+		),
+		color
+	)
 
 func render(replayer) -> void:
 	if replayer == null:

--- a/scenarios/scale_test_v1.gd
+++ b/scenarios/scale_test_v1.gd
@@ -7,7 +7,7 @@ const BattleInput = preload("res://schema/battle_input.gd")
 const GRID_WIDTH = 80
 const GRID_HEIGHT = 40
 const DEPLOY_WIDTH = 15
-const DEPLOY_HEIGHT = 28
+const DEPLOY_HEIGHT = 32
 const RED_ZONE_START = 0
 const BLUE_ZONE_START = GRID_WIDTH - DEPLOY_WIDTH
 

--- a/scenarios/scale_test_v1.gd
+++ b/scenarios/scale_test_v1.gd
@@ -18,13 +18,7 @@ const TIME_LIMIT_TICKS = 5000
 const DEFAULT_SEED = 12345
 
 static func build(seed: int = DEFAULT_SEED):
-	var input = BattleInput.new()
-	input.grid_width = GRID_WIDTH
-	input.grid_height = GRID_HEIGHT
-	input.max_units_per_tile = MAX_UNITS_PER_TILE
-	input.max_total_size_per_tile = MAX_TOTAL_SIZE_PER_TILE
-	input.seed = seed
-	input.time_limit_ticks = TIME_LIMIT_TICKS
+	var input = _build_base_input(seed)
 
 	var next_unit_id = 0
 	var next_squad_id = 0
@@ -32,6 +26,19 @@ static func build(seed: int = DEFAULT_SEED):
 	next_unit_id = result.next_unit_id
 	next_squad_id = result.next_squad_id
 	result = _populate_side(input, BattleConstants.Side.BLUE, BLUE_ZONE_START, next_unit_id, next_squad_id)
+	return input
+
+static func build_empty(seed: int = DEFAULT_SEED):
+	return _build_base_input(seed)
+
+static func _build_base_input(seed: int) -> BattleInput:
+	var input = BattleInput.new()
+	input.grid_width = GRID_WIDTH
+	input.grid_height = GRID_HEIGHT
+	input.max_units_per_tile = MAX_UNITS_PER_TILE
+	input.max_total_size_per_tile = MAX_TOTAL_SIZE_PER_TILE
+	input.seed = seed
+	input.time_limit_ticks = TIME_LIMIT_TICKS
 	return input
 
 static func _populate_side(input, side: int, zone_start: int, next_unit_id: int, next_squad_id: int) -> Dictionary:

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -20,6 +20,13 @@ var _last_event_log
 var _current_tps: int = DEFAULT_TPS
 var _allow_play_toggle: bool = false
 var _resume_playing_after_modal: bool = false
+var _custom_mode: bool = false
+var _setup_input
+var _placing_side: int = BattleConstants.Side.RED
+var _placing_unit_type: int = -1
+var _next_unit_id: int = 0
+var _next_squad_id: int = 0
+var _setup_tile_unit_count = PackedInt32Array()
 
 func _ready() -> void:
 	var args = OS.get_cmdline_args()
@@ -37,6 +44,10 @@ func _ready() -> void:
 	_battle_ui.step_requested.connect(_on_step_requested)
 	_battle_ui.speed_changed.connect(_on_speed_changed)
 	_battle_ui.unit_details_closed.connect(_on_unit_details_closed)
+	_battle_ui.custom_mode_toggled.connect(_on_custom_mode_toggled)
+	_battle_ui.placement_side_changed.connect(_on_placement_side_changed)
+	_battle_ui.placement_unit_selected.connect(_on_placement_unit_selected)
+	_battle_ui.placement_canceled.connect(_on_placement_canceled)
 
 	var input = ScaleTestV1.build()
 	_show_preview(input)
@@ -56,6 +67,11 @@ func _process(delta: float) -> void:
 			_replayer.update(delta)
 		_battle_view.render(_replayer)
 		_update_hover_panel()
+	if _battle_view != null:
+		if _custom_mode and not _resolving:
+			_update_ghost_preview()
+		else:
+			_battle_view.set_ghost_units([], true)
 
 	_update_debug_overlay()
 
@@ -68,12 +84,16 @@ func _start_resolve() -> void:
 	_battle_ui.set_playing(false)
 	_last_event_log = null
 	_last_result = null
+	if _custom_mode:
+		_battle_ui.clear_placement_selection()
 
 	_resolver_thread = Thread.new()
 	_resolver_thread.start(Callable(self, "_resolve_task"))
 
 func _resolve_task() -> Dictionary:
 	var input = ScaleTestV1.build()
+	if _custom_mode and _setup_input != null:
+		input = _setup_input
 	return BattleResolver.resolve(input)
 
 func _on_resolve_complete(result: Dictionary) -> void:
@@ -97,6 +117,16 @@ func _input(event) -> void:
 			_on_play_toggled(not _replayer.playing)
 
 func _unhandled_input(event) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		if event.button_index == MOUSE_BUTTON_RIGHT:
+			if _custom_mode and _placing_unit_type != -1 and _battle_ui != null:
+				_battle_ui.clear_placement_selection()
+				return
+		if event.button_index != MOUSE_BUTTON_LEFT:
+			return
+		if _custom_mode and _placing_unit_type != -1 and _is_setup_active():
+			if _try_place_squad():
+				return
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		if _resolving or _battle_view == null or _battle_ui == null or _replayer == null:
 			return
@@ -124,6 +154,36 @@ func _on_speed_changed(tps: int) -> void:
 	_current_tps = tps
 	if _replayer != null:
 		_replayer.set_ticks_per_second(tps)
+
+func _on_custom_mode_toggled(enabled: bool) -> void:
+	_custom_mode = enabled
+	_placing_unit_type = -1
+	if _battle_view != null:
+		_battle_view.set_ghost_units([], true)
+	if not enabled:
+		var input = ScaleTestV1.build()
+		_show_preview(input)
+		_allow_play_toggle = false
+		return
+
+	if _setup_input == null:
+		_setup_input = ScaleTestV1.build_empty()
+	_next_unit_id = _setup_input.unit_ids.size()
+	_next_squad_id = _setup_input.squad_ids.size()
+	_rebuild_setup_occupancy()
+	_show_preview(_setup_input)
+	_allow_play_toggle = false
+
+func _on_placement_side_changed(side: int) -> void:
+	_placing_side = side
+
+func _on_placement_unit_selected(unit_type: int) -> void:
+	_placing_unit_type = unit_type
+
+func _on_placement_canceled() -> void:
+	_placing_unit_type = -1
+	if _battle_view != null:
+		_battle_view.set_ghost_units([], true)
 
 func _open_unit_details(tile: Vector2i, units: Array) -> void:
 	if _battle_ui == null:
@@ -241,3 +301,170 @@ func _show_preview(input) -> void:
 	_replayer.initialize_from_log(log)
 	_replayer.set_ticks_per_second(_current_tps)
 	_replayer.set_playing(false)
+
+func _is_setup_active() -> bool:
+	return not _allow_play_toggle and not _resolving
+
+func _rebuild_setup_occupancy() -> void:
+	if _setup_input == null:
+		return
+	var tile_count = _setup_input.grid_width * _setup_input.grid_height
+	_setup_tile_unit_count.resize(tile_count)
+	for i in range(tile_count):
+		_setup_tile_unit_count[i] = 0
+	for i in range(_setup_input.unit_x.size()):
+		var ux = _setup_input.unit_x[i]
+		var uy = _setup_input.unit_y[i]
+		if ux < 0 or uy < 0:
+			continue
+		var tile = BattleConstants.tile_index(ux, uy, _setup_input.grid_width)
+		if tile >= 0 and tile < tile_count:
+			_setup_tile_unit_count[tile] += 1
+
+func _update_ghost_preview() -> void:
+	if not _custom_mode or _placing_unit_type == -1:
+		_battle_view.set_ghost_units([], true)
+		return
+	if _setup_input == null or _battle_view == null:
+		return
+	var anchor = _battle_view.get_hovered_tile()
+	if anchor.x < 0:
+		_battle_view.set_ghost_units([], true)
+		return
+	var layout = _build_squad_layout(_placing_unit_type, BattleConstants.MAX_SQUAD_SIZE)
+	var tiles = _layout_world_tiles(layout, anchor, _placing_side)
+	var valid = _is_layout_valid(tiles)
+	var ghost_units = _build_ghost_units(layout, tiles, _placing_unit_type, _placing_side)
+	_battle_view.set_ghost_units(ghost_units, valid)
+
+func _try_place_squad() -> bool:
+	if _setup_input == null or _battle_view == null:
+		return false
+	var anchor = _battle_view.get_hovered_tile()
+	if anchor.x < 0:
+		return false
+	var layout = _build_squad_layout(_placing_unit_type, BattleConstants.MAX_SQUAD_SIZE)
+	var tiles = _layout_world_tiles(layout, anchor, _placing_side)
+	if not _is_layout_valid(tiles):
+		return false
+	var squad_id = _next_squad_id
+	_next_squad_id += 1
+	_setup_input.squad_ids.append(squad_id)
+	_setup_input.squad_sides.append(_placing_side)
+	_setup_input.squad_formations.append(BattleConstants.Formation.SQUARE)
+
+	var unit_size = BattleConstants.UNIT_SIZE[_placing_unit_type]
+	for i in range(tiles.size()):
+		var tile = tiles[i]
+		var count = layout["tile_units"][i]
+		var tile_index = BattleConstants.tile_index(tile.x, tile.y, _setup_input.grid_width)
+		for j in range(count):
+			var unit_id = _next_unit_id
+			_next_unit_id += 1
+			_setup_input.unit_ids.append(unit_id)
+			_setup_input.unit_sides.append(_placing_side)
+			_setup_input.unit_types.append(_placing_unit_type)
+			_setup_input.unit_sizes.append(unit_size)
+			_setup_input.unit_x.append(tile.x)
+			_setup_input.unit_y.append(tile.y)
+			_setup_input.unit_next_tick.append(0)
+			_setup_input.unit_squad_ids.append(squad_id)
+			if tile_index >= 0 and tile_index < _setup_tile_unit_count.size():
+				_setup_tile_unit_count[tile_index] += 1
+
+	_show_preview(_setup_input)
+	return true
+
+func _build_squad_layout(unit_type: int, squad_size: int) -> Dictionary:
+	var unit_size = BattleConstants.UNIT_SIZE[unit_type]
+	var max_units = _setup_input.max_units_per_tile
+	var max_total_size = _setup_input.max_total_size_per_tile
+	var tile_units = []
+	var current_count = 0
+	var current_size = 0
+
+	for i in range(squad_size):
+		if current_count >= max_units or current_size + unit_size > max_total_size:
+			tile_units.append(current_count)
+			current_count = 0
+			current_size = 0
+		current_count += 1
+		current_size += unit_size
+	if current_count > 0:
+		tile_units.append(current_count)
+
+	var formation = _square_tile_positions(tile_units.size())
+	return {
+		"tile_units": tile_units,
+		"positions": formation["positions"],
+		"width": formation["width"],
+		"height": formation["height"],
+	}
+
+func _square_tile_positions(tile_count: int) -> Dictionary:
+	var width = int(ceil(sqrt(float(tile_count))))
+	if width < 1:
+		width = 1
+	var height = int(ceil(float(tile_count) / float(width)))
+	if height < 1:
+		height = 1
+
+	var positions = []
+	var remaining = tile_count
+	for y in range(height):
+		for x in range(width):
+			if remaining <= 0:
+				break
+			positions.append(Vector2i(x, y))
+			remaining -= 1
+		if remaining <= 0:
+			break
+
+	return {
+		"width": width,
+		"height": height,
+		"positions": positions,
+	}
+
+func _layout_world_tiles(layout: Dictionary, anchor: Vector2i, side: int) -> Array:
+	var tiles = []
+	var positions: Array = layout["positions"]
+	for local in positions:
+		var pos = local as Vector2i
+		var world_x = anchor.x + pos.x
+		if side == BattleConstants.Side.RED:
+			world_x = anchor.x - pos.x
+		var world_y = anchor.y + pos.y
+		tiles.append(Vector2i(world_x, world_y))
+	return tiles
+
+func _is_layout_valid(tiles: Array) -> bool:
+	if _setup_input == null:
+		return false
+	for tile in tiles:
+		var pos = tile as Vector2i
+		if pos.x < 0 or pos.y < 0 or pos.x >= _setup_input.grid_width or pos.y >= _setup_input.grid_height:
+			return false
+		var tile_index = BattleConstants.tile_index(pos.x, pos.y, _setup_input.grid_width)
+		if tile_index < 0 or tile_index >= _setup_tile_unit_count.size():
+			return false
+		if _setup_tile_unit_count[tile_index] > 0:
+			return false
+	return true
+
+func _build_ghost_units(layout: Dictionary, tiles: Array, unit_type: int, side: int) -> Array:
+	var ghost_units = []
+	for i in range(tiles.size()):
+		var tile = tiles[i] as Vector2i
+		if tile.x < 0 or tile.y < 0 or tile.x >= _setup_input.grid_width or tile.y >= _setup_input.grid_height:
+			continue
+		var count = int(layout["tile_units"][i])
+		for slot in range(count):
+			ghost_units.append({
+				"type": unit_type,
+				"x": tile.x,
+				"y": tile.y,
+				"slot": slot,
+				"side": side,
+			})
+	return ghost_units

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -166,8 +166,7 @@ func _on_custom_mode_toggled(enabled: bool) -> void:
 		_allow_play_toggle = false
 		return
 
-	if _setup_input == null:
-		_setup_input = ScaleTestV1.build_empty()
+	_setup_input = ScaleTestV1.build_empty()
 	_next_unit_id = _setup_input.unit_ids.size()
 	_next_squad_id = _setup_input.squad_ids.size()
 	_rebuild_setup_occupancy()

--- a/ui/battle_ui.gd
+++ b/ui/battle_ui.gd
@@ -6,6 +6,10 @@ signal play_toggled(playing: bool)
 signal step_requested
 signal speed_changed(ticks_per_second: int)
 signal unit_details_closed
+signal custom_mode_toggled(enabled: bool)
+signal placement_side_changed(side: int)
+signal placement_unit_selected(unit_type: int)
+signal placement_canceled
 
 var _resolve_button: Button
 var _play_button: Button
@@ -21,6 +25,12 @@ var _hover_panel: PanelContainer
 var _hover_title: Label
 var _hover_entries = []
 var _unit_textures = []
+var _setup_panel: PanelContainer
+var _custom_toggle: CheckBox
+var _side_option: OptionButton
+var _unit_buttons = []
+var _cancel_placement: Button
+var _selected_unit_type: int = -1
 var _details_backdrop: ColorRect
 var _details_panel: PanelContainer
 var _details_title: Label
@@ -157,6 +167,7 @@ func _ready() -> void:
 	overlay_box.add_child(_spinner_label)
 
 	set_start_overlay_visible(true)
+	_build_setup_panel()
 	_build_hover_panel()
 	_build_unit_details_modal()
 
@@ -168,6 +179,8 @@ func set_resolving(resolving: bool) -> void:
 	_start_button.disabled = resolving
 	_status_label.text = "Resolving..." if resolving else ""
 	_spinner_label.visible = resolving
+	if _setup_panel != null and _start_overlay != null:
+		_setup_panel.visible = _start_overlay.visible and not resolving
 	if resolving:
 		_spinner_index = 0
 		_spinner_elapsed = 0.0
@@ -180,6 +193,8 @@ func set_playing(playing: bool) -> void:
 func set_start_overlay_visible(visible: bool) -> void:
 	_start_overlay.visible = visible
 	_panel.visible = not visible
+	if _setup_panel != null:
+		_setup_panel.visible = visible
 
 func set_debug_text(text: String) -> void:
 	_debug_label.text = text
@@ -230,6 +245,51 @@ func _on_step_pressed() -> void:
 func _on_speed_selected(index: int) -> void:
 	var tps = _speed_option.get_item_id(index)
 	emit_signal("speed_changed", tps)
+
+func clear_placement_selection() -> void:
+	if _selected_unit_type == -1:
+		return
+	_selected_unit_type = -1
+	_update_unit_button_states()
+	emit_signal("placement_canceled")
+
+func _set_custom_controls_enabled(enabled: bool) -> void:
+	if _side_option != null:
+		_side_option.disabled = not enabled
+	if _cancel_placement != null:
+		_cancel_placement.disabled = not enabled
+	for entry in _unit_buttons:
+		entry["button"].disabled = not enabled
+	if not enabled:
+		_selected_unit_type = -1
+		_update_unit_button_states()
+
+func _update_unit_button_states() -> void:
+	for entry in _unit_buttons:
+		var button: Button = entry["button"]
+		var unit_type = int(entry["type"])
+		button.button_pressed = unit_type == _selected_unit_type
+
+func _on_custom_toggled(enabled: bool) -> void:
+	_set_custom_controls_enabled(enabled)
+	emit_signal("custom_mode_toggled", enabled)
+
+func _on_side_selected(index: int) -> void:
+	var side = _side_option.get_item_id(index)
+	emit_signal("placement_side_changed", side)
+
+func _on_unit_button_pressed(unit_type: int) -> void:
+	if _custom_toggle == null or not _custom_toggle.button_pressed:
+		return
+	if _selected_unit_type == unit_type:
+		clear_placement_selection()
+		return
+	_selected_unit_type = unit_type
+	_update_unit_button_states()
+	emit_signal("placement_unit_selected", unit_type)
+
+func _on_cancel_pressed() -> void:
+	clear_placement_selection()
 
 func _process(delta: float) -> void:
 	if not _resolving:
@@ -287,6 +347,63 @@ func _build_hover_panel() -> void:
 			"icon": icon,
 			"label": label,
 		})
+
+func _build_setup_panel() -> void:
+	_setup_panel = PanelContainer.new()
+	_setup_panel.position = Vector2(10, 220)
+	add_child(_setup_panel)
+
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+	_setup_panel.add_child(vbox)
+
+	var title = Label.new()
+	title.text = "Custom Setup"
+	vbox.add_child(title)
+
+	_custom_toggle = CheckBox.new()
+	_custom_toggle.text = "Enable custom armies"
+	_custom_toggle.toggled.connect(_on_custom_toggled)
+	vbox.add_child(_custom_toggle)
+
+	var side_label = Label.new()
+	side_label.text = "Placing side"
+	vbox.add_child(side_label)
+
+	_side_option = OptionButton.new()
+	_side_option.add_item("Red Army", 0)
+	_side_option.add_item("Blue Army", 1)
+	_side_option.select(0)
+	_side_option.item_selected.connect(_on_side_selected)
+	vbox.add_child(_side_option)
+
+	var unit_label = Label.new()
+	unit_label.text = "Place squad (50)"
+	vbox.add_child(unit_label)
+
+	var grid = GridContainer.new()
+	grid.columns = 2
+	grid.add_theme_constant_override("h_separation", 6)
+	grid.add_theme_constant_override("v_separation", 6)
+	vbox.add_child(grid)
+
+	for i in range(UNIT_NAMES.size()):
+		var button = Button.new()
+		button.text = UNIT_NAMES[i]
+		button.toggle_mode = true
+		button.pressed.connect(Callable(self, "_on_unit_button_pressed").bind(i))
+		grid.add_child(button)
+		_unit_buttons.append({
+			"type": i,
+			"button": button,
+		})
+
+	_cancel_placement = Button.new()
+	_cancel_placement.text = "Cancel placement"
+	_cancel_placement.pressed.connect(_on_cancel_pressed)
+	vbox.add_child(_cancel_placement)
+
+	_set_custom_controls_enabled(false)
 
 func _build_unit_details_modal() -> void:
 	_details_backdrop = ColorRect.new()


### PR DESCRIPTION
## Summary
- switch custom setup to a CLI flag (--custom-setup) and remove the on-screen toggle
- enforce deployment zones (32 tiles tall, 4-tile margins top/bottom) with red/blue overlays and placement validation
- update custom squad sizes (infantry types 64, cavalry types 48, others 50) and show unit icons on selection buttons

## Decisions
- anchor placement to the hovered tile as the front edge (blue extends right, red extends left) to keep square formations predictable
- enforce strict placement by disallowing any overlap with existing units on a tile
- keep archers/mages at 50 until a different size is specified

## Testing
- ./run.sh --headless --resolve-only
