### PR TITLE
Formation-aware movement and cached distance fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ From the project root:
 - macOS/Linux (bash/zsh): `./run.sh`
 - Windows (PowerShell): `.\run.ps1`
 
-Headless resolve (no rendering):
-- `./run.sh --headless --resolve-only`
+Headless resolve (no rendering, `--resolve-only` auto-adds `--headless`):
+- `./run.sh --resolve-only`
 - `.\run.ps1 --resolve-only`
+
+Resolve profiling (prints timing breakdown):
+- `./run.sh --resolve-only --profile-resolve`
+- `.\run.ps1 --resolve-only --profile-resolve`
 
 Custom battle setup (manual placement UI):
 - `./run.sh --custom-setup`

--- a/docs/tick_battle_scale_prototype_godot45_requirements.md
+++ b/docs/tick_battle_scale_prototype_godot45_requirements.md
@@ -97,19 +97,18 @@ This is the single biggest lever for scale.
 
 ---
 
-## 7. Pathing Implementation (Distance Field)
+## 7. Pathing & Formation Movement
 
-Implement the base document’s **soft-cost Dijkstra** approach:
+Follow the base document and the **Squad-Aware Pathing & Formations companion guide** (`docs/tick_battle_scale_prototype_squad_pathing_companion.md`).
 
-Per tick (or when you choose to recompute):
-1. Build passability + cost data for size-2 and size-3 movers.
-2. Run a multi-source **Dijkstra** seeded from enemy-occupied tiles.
-   - Empty tile cost = 1
-   - Friendly tile cost = 1 + (friendly unit count × penalty)
-   - Enemy tiles are blocked
-3. Each moving unit picks a neighbor tile with the lowest distance that is passable.
-
-Keep tie-breaking deterministic (fixed neighbor order).
+Required implementation shape:
+- Build multi-source **Dijkstra** distance fields per side + size (terrain + objectives only).
+- Drive a per-squad **anchor** along the field.
+- Per unit, choose moves with **goal slack + formation tie-break** (include `stay`).
+- Apply movement in **two phases** (intent then conflict resolution).
+- Use deterministic tie-breaks for both Dijkstra and move resolution.
+ - Cache fields per `(side, size)` and rebuild on a cadence (dirty + `REBUILD_INTERVAL_TICKS`, or `MAX_STALE_TICKS` safety).
+ - A BFS fast path is allowed when all edge costs are uniform.
 
 ---
 

--- a/docs/tick_battle_scale_prototype_squad_pathing_companion.md
+++ b/docs/tick_battle_scale_prototype_squad_pathing_companion.md
@@ -1,0 +1,468 @@
+# Squad-Aware Pathing & Formations — Companion Implementation Guide (Prototype)
+
+**Audience:** Codex (primary implementer).  
+**Reviewer/QA/Direction:** You (project owner).
+
+This is a companion to:
+- `tick_battle_scale_prototype_godot45_requirements.md` (Section 7 now points here).
+
+---
+
+## 0. Scope Update
+
+Squads + formations are now **in scope** for the prototype. This guide specifies the definitive approach we will implement first.
+
+### Design goals
+
+1. **Standard marches stay cohesive** on clear ground.
+2. **Malleable around obstacles / choke points** (squads snake/compress as needed).
+3. **Mixed speeds + debuffs** (slow/paralyzed units do not stall the whole squad).
+4. **Deterministic & scalable** (thousands of units; dozens of squads; replay hash stable).
+5. **Low tuning overhead**: avoid “weight soup” and brittle logic.
+
+### Non-goals (for this prototype pass)
+
+- Perfect formation locking / collision-free marching in all edge cases.
+- Full group-level A* (anchor + flow field is the intended scale strategy).
+- Optimal slot assignment (we’ll do a simple deterministic repack only if needed).
+
+---
+
+## 1. Definitive Approach To Implement
+
+### Summary
+
+We will implement:
+
+1. **Strategic distance field (flow field)** via multi-source **Dijkstra** per side + movement profile + size.
+   - **Terrain + objectives only.**
+   - **Do not** include friendly occupancy as Dijkstra cost.
+
+2. **Squad anchor** follows the strategic field.
+   - One “anchor move” decision per squad instead of per unit.
+
+3. **Unit movement uses “Goal-Slack + Formation Tie-Break”.**
+   - Evaluate a tiny set of candidate moves.
+   - Choose the best **goal progress** move(s), then pick the one that best preserves formation.
+   - Only a handful of knobs: `SLACK_BASE`, `SLACK_CHOKE_BONUS`, `DETACH_DIST`, occupancy rules.
+
+4. **Two-phase movement application** for units that activate on the same tick.
+   - Phase A: compute intents.
+   - Phase B: deterministic conflict resolution, then apply.
+
+This combination specifically targets your current failure mode: “rear ranks try to path around the front and instantly break formation.”
+
+---
+
+## 2. Key Concepts & Terms
+
+- **Strategic field**: `dist[tile]` that encodes “how close am I to the enemy/objective.” Lower is better.
+- **Anchor**: a virtual squad reference point. The squad’s formation slots are defined relative to it.
+- **Desired slot**: target tile for a unit when formation is healthy.
+- **Slack**: how much worse a move is allowed to be (in goal-distance terms) in order to preserve formation.
+
+---
+
+## 3. Data Additions (Schema + Resolver State)
+
+### 3.1 Per-unit additions (SoA arrays)
+
+Add to existing unit storage:
+
+- `squad_id[id] : int` (`-1` if none)
+- `slot_dx[id], slot_dy[id] : int`
+  - slot offset when squad facing is **North** (canonical orientation)
+- `attached[id] : bool`
+  - whether the unit is currently expected to adhere to formation strongly
+- `keep_formation_in_melee[id] : bool` (or derive from unit type)
+
+Optional (but helpful):
+- `stuck_count[id] : int` (increment when a unit wants to move but can’t)
+
+### 3.2 Per-squad state
+
+- `anchor_x[s], anchor_y[s] : int`
+- `anchor_next_tick[s] : int`
+- `anchor_delay[s] : int`
+  - squad “march cadence” (recommend median base move delay of members; see §7)
+- `facing_dir[s] : int` (0=N,1=E,2=S,3=W)
+- `slack_base[s] : int` (start with 1–2)
+- `slack_choke_bonus[s] : int` (start with 2)
+- `formation_enabled[s] : bool`
+- `movement_profile[s] : int` (foot/cav/amphib/etc)
+- `size_profile[s] : int` (usually max size among members)
+
+### 3.3 Map / terrain state
+
+- `terrain_type[tile] : int`
+- `terrain_version : int` (increment on spell changes)
+
+### 3.4 Occupancy index
+
+Use existing per-tile occupancy summary:
+- `tile_total_size[tile]`
+- `tile_side[tile]` (or mixed/none)
+- `tile_unit_ids[]` (optional list)
+
+Define a tile capacity rule:
+- `TILE_CAPACITY = 4` (matches “up to 4 units per tile” rendering assumption)
+
+---
+
+## 4. Strategic Field Build (Dijkstra)
+
+### 4.1 Why
+
+- We need terrain weights (woods, hills, water, boulders) and unit-specific movement.
+- Grid is small (~80×40 typical), so Dijkstra is cheap.
+
+### 4.2 Field dimensions
+
+Compute fields:
+
+- Per **side**: `dist_side[side][profile][size][tile]`
+- Profiles: start with 1 profile for the prototype if needed, but structure for more.
+- Sizes: at least size-2 and size-3, as per the base requirements.
+
+### 4.3 Seeds (objective definition)
+
+Prototype seed rule (keep it simple):
+- Multi-source seed = all tiles occupied by **enemy** units.
+- Seed distance = 0 on those tiles.
+
+(If enemy tiles are impassable, seed adjacent passable tiles instead.)
+
+### 4.4 Tile traversal cost
+
+Provide a function:
+
+- `step_cost(profile, size, tile_from, tile_to) -> int`
+
+Rules:
+- If `tile_to` is impassable for this (profile,size), it is not expanded.
+- Cost must be **integer** for determinism and easy slack tuning.
+
+Important: **Do not include friendly occupancy in this step cost.**
+
+### 4.5 Determinism for Dijkstra
+
+Use a priority queue with a stable tie-break:
+- Key = `(dist, tile_index)`
+- `tile_index = y * width + x`
+
+This ensures consistent behavior even when distances tie.
+
+### 4.6 Recompute schedule
+
+- Maintain cached fields per `(side, profile, size)` and rebuild only when needed.
+- Track `terrain_version` plus `occupancy_version[side]` (increment when a unit of that side moves/spawns/dies).
+- Rebuild when dirty **and** `tick >= last_build_tick + REBUILD_INTERVAL_TICKS`.
+- Always rebuild if `tick >= last_build_tick + MAX_STALE_TICKS` (safety).
+- A stale guard can set `force_rebuild` if units repeatedly fail to improve goal distance.
+
+### 4.7 Uniform-cost fast path
+
+If all edge costs are 1, a multi-source BFS is equivalent to Dijkstra and is much faster in GDScript. Keep the same API and switch to PQ-based Dijkstra when terrain costs become non-uniform.
+
+---
+
+## 5. Squad Anchor Update
+
+### 5.1 When the anchor moves
+
+Anchor moves when `tick >= anchor_next_tick[s]`:
+
+- Look up the correct field:
+  - side = squad’s side
+  - profile = `movement_profile[s]`
+  - size = `size_profile[s]`
+
+- Consider candidate moves: `{stay, N, S, E, W}`
+- Choose move that minimizes `dist[tile]` (deterministic neighbor order)
+- If no neighbor improves `dist`, anchor stays.
+
+After decision:
+- If anchor moved, update `facing_dir` to that direction.
+- `anchor_next_tick[s] += anchor_delay[s]`
+
+### 5.2 Why anchor speed is separate from unit speed
+
+- Mixed speed squads exist.
+- Debuffs/paralysis exist.
+- We **do not** want the anchor cadence to be dictated by the slowest or incapacitated member.
+
+Prototype rule:
+- `anchor_delay[s] = median(base_move_delay[unit_type])` across alive members.
+- Ignore temporarily slowed/paralyzed effects for the anchor.
+
+---
+
+## 6. Unit Move Choice (Goal-Slack + Formation Tie-Break)
+
+This is the core formation behavior.
+
+### 6.1 Candidate set
+
+For an activating unit `u`, define candidate tiles:
+
+- `C = { current (stay), N, S, E, W }`
+
+Filter out candidates that are impassable for that unit’s profile/size.
+
+### 6.2 Compute goal cost per candidate
+
+For each candidate tile `p`:
+
+`goal_cost(p) = dist[p] + local_occupancy_penalty(u, p)`
+
+Local occupancy handling (prototype rules):
+
+- If `tile_total_size[p] + size[u] > TILE_CAPACITY` → treat as **blocked**.
+- Friendly occupancy is allowed (soft), but add a small penalty:
+  - `FRIEND_PENALTY = 1` (start here)
+  - (Optionally scale with crowding: +1 per extra size already in tile)
+- Enemy occupancy: treat as blocked for movement (engagement handled elsewhere).
+
+### 6.3 Build the “good enough” set with slack
+
+Let:
+
+- `best = min(goal_cost(p))` over passable candidates
+- `slack = squad_slack(u)` (see §6.6)
+
+Define:
+
+- `S = { p in C | goal_cost(p) <= best + slack }`
+
+This means: “only consider moves that are near-best for strategic progress.”
+
+### 6.4 Formation tie-break
+
+If the unit is in formation mode (see §6.5), compute desired slot tile:
+
+- `desired = anchor + rotate(slot_dx[u], slot_dy[u], facing_dir[squad])`
+
+Then choose from `S` the tile `p` minimizing:
+
+- `form_error(p) = manhattan_distance(p, desired)`
+
+Final tie-break order (deterministic):
+
+1. smallest `form_error(p)`
+2. smallest `goal_cost(p)`
+3. fixed neighbor order (e.g., stay, N, E, S, W)
+
+### 6.5 When formation is “active” for a unit
+
+Formation is active if:
+
+- `squad_id[u] != -1`
+- `formation_enabled[squad] == true`
+- `attached[u] == true`
+- and either:
+  - `keep_formation_in_melee[u] == true`, OR
+  - `u` is not engaged (no adjacent enemy)
+
+(Engagement break is optional per unit type.)
+
+### 6.6 Computing `squad_slack(u)`
+
+Keep this extremely simple.
+
+Start with:
+
+- `slack = slack_base[squad]`
+
+Then add a choke bonus if the squad is congested:
+
+- Compute `blocked_ratio` for the squad each tick:
+  - among **attached** units that activated this tick, how many had `chosen_move == stay` while their `best` move was not stay?
+
+If `blocked_ratio >= 0.5` then:
+
+- `slack += slack_choke_bonus[squad]`
+
+That’s it. One threshold, one bonus.
+
+Rationale:
+- On open ground: low blocked_ratio ⇒ formation stays tight.
+- At choke: high blocked_ratio ⇒ formation loosens enough to snake through.
+
+---
+
+## 7. Unit Tick Scheduling (Speed, Terrain, Status)
+
+Your architecture already supports per-unit activation (`next_tick[id]`). Keep that and let speed emerge from tick scheduling.
+
+### 7.1 Move delay
+
+When a unit moves into `p`, set:
+
+- `next_tick[u] += move_delay(unit_type[u], terrain_type[p], status_effects[u])`
+
+Prototype: if statuses aren’t implemented yet, just use `terrain_type[p]` and unit base speed.
+
+Examples:
+- cavalry on open: 6
+- infantry on open: 10
+- cavalry in woods: 10 (advantage removed)
+- paralyzed: very large delay or “cannot move” flag (still can fight)
+
+### 7.2 Why this avoids “rewrite tons of pathfinding code”
+
+- The strategic field stays the same.
+- Only `move_delay()` and movement profile selection changes as mechanics expand.
+
+---
+
+## 8. Attached / Detached (Stragglers Without Stalling The Squad)
+
+### 8.1 Detach rule (prototype)
+
+When a unit activates, compute its current desired slot tile (even if it won’t adhere) and:
+
+- `err = manhattan_distance(current_pos, desired)`
+
+If:
+
+- `err > DETACH_DIST` (start with 6–10 tiles)
+
+Then:
+
+- `attached[u] = false`
+
+Detached units:
+- Ignore formation tie-break (or treat `slack` as very large).
+- Still use the same strategic field + local occupancy rules.
+
+### 8.2 Reattach rule
+
+If detached and:
+
+- `err <= REATTACH_DIST` (smaller than detach; start with 4–6)
+
+Then:
+
+- `attached[u] = true`
+
+Use hysteresis (two thresholds) to avoid flip-flopping.
+
+---
+
+## 9. Two-Phase Move Application (Conflict Resolution)
+
+### 9.1 Why
+
+Applying moves immediately in a single pass causes rear units to treat front units as static obstacles. Two-phase application reduces that and makes formation cohesion much more stable.
+
+### 9.2 Implementation
+
+At each simulation tick `t`:
+
+1. **Collect active units**: all `u` with `alive[u] && next_tick[u] <= t`.
+2. **Compute intents**: for each active unit, compute intended target tile `intent[u]`.
+3. **Resolve conflicts** deterministically.
+4. **Apply** the winning moves simultaneously (update positions + occupancy + next_tick).
+
+### 9.3 Conflict rules (prototype)
+
+- If a tile can accept multiple units up to `TILE_CAPACITY`, treat it as a capacity problem:
+  - accept intents in priority order until full, remaining units stay.
+
+Priority order (deterministic, formation-friendly):
+
+1. `squad_id` ascending (non-squad units after squads)
+2. within squad: **front-to-back** order
+   - compute each unit’s “rank” from its slot offset projected onto `facing_dir`
+3. then `unit_id` ascending
+
+This helps prevent “rear overtakes front.”
+
+(We can add same-squad chain-move support later if needed, but start here.)
+
+---
+
+## 10. Debugging & Instrumentation (Required)
+
+Add a debug overlay mode that can be toggled:
+
+Per squad:
+- draw anchor tile
+- draw facing arrow
+- display `slack` and whether choke bonus is active
+- display `anchor_delay`
+
+Per unit (optional):
+- if selected/hovered, draw desired slot tile
+- print `attached` + `err`
+
+Metrics:
+- average formation error per squad (`avg err` over attached units)
+- percent detached
+
+---
+
+## 11. Acceptance Tests (Prototype)
+
+### Test A — Clear march
+
+- Two squads, wide open map.
+- Expect: ranks remain aligned; minimal lateral drift.
+
+### Test B — Choke point
+
+- Add walls with a 1–2 tile gap.
+- Expect: squad compresses/snakes through; reforms afterward.
+
+### Test C — Paralyzed straggler
+
+- Apply “cannot move” to a rear unit.
+- Expect: squad continues; straggler detaches; does not cause the squad to explode.
+
+### Test D — Mixed speed
+
+- Mix cav + infantry.
+- Expect: cav does not permanently peel off sideways; either waits or becomes detached depending on thresholds.
+
+---
+
+## 12. Implementation Plan (Codex)
+
+### Phase 1 — Field + anchor + basic formation tie-break
+
+- [ ] Remove friendly soft-blocking cost from strategic Dijkstra.
+- [ ] Add squad anchor state + update rule.
+- [ ] Implement unit move choice with goal-slack + formation tie-break.
+- [ ] Add “stay” candidate.
+
+### Phase 2 — Two-phase move + deterministic conflict
+
+- [ ] Intent pass for active units.
+- [ ] Conflict resolution with formation-friendly priority.
+- [ ] Apply simultaneously.
+
+### Phase 3 — Detach/reattach + choke slack
+
+- [ ] `attached` + detach/reattach thresholds.
+- [ ] blocked_ratio → slack bonus.
+- [ ] melee break toggle.
+
+Stop after Phase 3 and assess visuals.
+
+---
+
+## 13. Default Knobs (Start Here)
+
+These are intentionally few.
+
+- `TILE_CAPACITY = 4`
+- `FRIEND_PENALTY = 1`
+- `slack_base = 2`
+- `slack_choke_bonus = 2`
+- `DETACH_DIST = 8`
+- `REATTACH_DIST = 5`
+
+If formation still shears on clear ground:
+- increase `slack_base` by 1 (more formation preference)
+- increase `FRIEND_PENALTY` by 1 (more queueing)
+- ensure “stay” is included and is not artificially penalized

--- a/resolver/battle_resolver.gd
+++ b/resolver/battle_resolver.gd
@@ -8,11 +8,32 @@ const BattleResult = preload("res://schema/battle_result.gd")
 
 const INF_DISTANCE = 1_000_000
 const STALL_TICK_LIMIT = 0
-const SOFT_COST_EMPTY = 1
-const SOFT_COST_FRIENDLY_PER_UNIT = 1
+const BASE_STEP_COST = 1
+const FRIEND_PENALTY = 1
+const SLACK_BASE = 2
+const SLACK_CHOKE_BONUS = 2
+const DETACH_DIST = 8
+const REATTACH_DIST = 5
+const REBUILD_INTERVAL_TICKS = 8
+const MAX_STALE_TICKS = 32
+const STALE_GUARD_THRESHOLD = 4
+const USE_UNIFORM_COST_BFS = true
 
-static func resolve(input) -> Dictionary:
+static func resolve(input, profile: bool = false) -> Dictionary:
 	var start_ms = Time.get_ticks_msec()
+	var profile_enabled = profile
+	var profile_start_usec = 0
+	if profile_enabled:
+		profile_start_usec = Time.get_ticks_usec()
+	var time_impacts_usec = 0
+	var time_field_build_usec = 0
+	var time_anchor_usec = 0
+	var time_unit_phase_usec = 0
+	var time_move_apply_usec = 0
+	var time_blocked_usec = 0
+	var profile_ticks = 0
+	var profile_active_units = 0
+	var profile_move_units = 0
 	var rng = XorShift32.new(input.seed)
 	var event_log = EventLog.new()
 
@@ -46,6 +67,21 @@ static func resolve(input) -> Dictionary:
 		next_tick.resize(unit_count)
 		for i in range(unit_count):
 			next_tick[i] = 0
+	var unit_squad_id = input.unit_squad_ids.duplicate()
+	if unit_squad_id.size() < unit_count:
+		unit_squad_id.resize(unit_count)
+		for i in range(unit_count):
+			unit_squad_id[i] = -1
+	var unit_slot_dx = input.unit_slot_dx.duplicate()
+	var unit_slot_dy = input.unit_slot_dy.duplicate()
+	if unit_slot_dx.size() < unit_count:
+		unit_slot_dx.resize(unit_count)
+		for i in range(unit_count):
+			unit_slot_dx[i] = 0
+	if unit_slot_dy.size() < unit_count:
+		unit_slot_dy.resize(unit_count)
+		for i in range(unit_count):
+			unit_slot_dy[i] = 0
 
 	var tile_side = PackedInt32Array()
 	tile_side.resize(tile_count)
@@ -74,7 +110,112 @@ static func resolve(input) -> Dictionary:
 			BattleConstants.encode_pos(unit_x[id], unit_y[id])
 		)
 
+	var squad_ids = input.squad_ids.duplicate()
+	var squad_sides = input.squad_sides.duplicate()
+	var squad_formations = input.squad_formations.duplicate()
+	var squad_count = squad_ids.size()
+
+	var squad_index_by_id = {}
+	for i in range(squad_count):
+		squad_index_by_id[squad_ids[i]] = i
+
+	var unit_squad_index = PackedInt32Array()
+	unit_squad_index.resize(unit_count)
+	for i in range(unit_count):
+		var squad_id = unit_squad_id[i]
+		if squad_index_by_id.has(squad_id):
+			unit_squad_index[i] = squad_index_by_id[squad_id]
+		else:
+			unit_squad_index[i] = -1
+
+	var squad_units = []
+	squad_units.resize(squad_count)
+	for i in range(squad_count):
+		squad_units[i] = []
+	for i in range(unit_count):
+		var s_index = unit_squad_index[i]
+		if s_index != -1:
+			squad_units[s_index].append(i)
+
+	var squad_anchor_x = PackedInt32Array()
+	var squad_anchor_y = PackedInt32Array()
+	var squad_anchor_next_tick = PackedInt32Array()
+	var squad_anchor_delay = PackedInt32Array()
+	var squad_facing = PackedInt32Array()
+	var squad_slack_base = PackedInt32Array()
+	var squad_slack_bonus = PackedInt32Array()
+	var squad_choke_active = PackedInt32Array()
+	var squad_size_profile = PackedInt32Array()
+	var squad_formation_enabled = PackedInt32Array()
+
+	squad_anchor_x.resize(squad_count)
+	squad_anchor_y.resize(squad_count)
+	squad_anchor_next_tick.resize(squad_count)
+	squad_anchor_delay.resize(squad_count)
+	squad_facing.resize(squad_count)
+	squad_slack_base.resize(squad_count)
+	squad_slack_bonus.resize(squad_count)
+	squad_choke_active.resize(squad_count)
+	squad_size_profile.resize(squad_count)
+	squad_formation_enabled.resize(squad_count)
+
+	for s in range(squad_count):
+		squad_anchor_x[s] = -1
+		squad_anchor_y[s] = -1
+		squad_anchor_next_tick[s] = 0
+		squad_anchor_delay[s] = 1
+		var side_value = squad_sides[s] if s < squad_sides.size() else BattleConstants.Side.RED
+		squad_facing[s] = BattleConstants.Dir.EAST if side_value == BattleConstants.Side.RED else BattleConstants.Dir.WEST
+		squad_slack_base[s] = SLACK_BASE
+		squad_slack_bonus[s] = SLACK_CHOKE_BONUS
+		squad_choke_active[s] = 0
+		squad_size_profile[s] = 2
+		squad_formation_enabled[s] = 1 if (s < squad_formations.size() and squad_formations[s] == BattleConstants.Formation.SQUARE) else 0
+
+	for s in range(squad_count):
+		var members: Array = squad_units[s]
+		if members.is_empty():
+			continue
+		var max_size = 0
+		for id in members:
+			max_size = max(max_size, unit_size[id])
+		squad_size_profile[s] = max_size
+		squad_anchor_delay[s] = _median_move_delay(members, unit_type)
+		var first_id = members[0]
+		var facing = squad_facing[s]
+		var offset = _rotate_offset(Vector2i(unit_slot_dx[first_id], unit_slot_dy[first_id]), facing)
+		squad_anchor_x[s] = unit_x[first_id] - offset.x
+		squad_anchor_y[s] = unit_y[first_id] - offset.y
+
+	var unit_attached = PackedInt32Array()
+	unit_attached.resize(unit_count)
+	var unit_keep_formation_in_melee = PackedInt32Array()
+	unit_keep_formation_in_melee.resize(unit_count)
+	for i in range(unit_count):
+		unit_attached[i] = 1 if unit_squad_index[i] != -1 else 0
+		unit_keep_formation_in_melee[i] = 0 if _is_melee_unit(unit_type[i]) else 1
+
+	var unit_no_progress = PackedInt32Array()
+	unit_no_progress.resize(unit_count)
+	for i in range(unit_count):
+		unit_no_progress[i] = 0
+
+	var max_unit_size = _max_unit_size(unit_size)
+	var field_cache = []
+	field_cache.resize(2)
+	for side_value in range(2):
+		field_cache[side_value] = []
+		field_cache[side_value].resize(max_unit_size + 1)
+		for size_value in range(max_unit_size + 1):
+			field_cache[side_value][size_value] = FieldCache.new()
+
 	var neighbors = _build_neighbors(width, height)
+
+	var terrain_version = 0
+	var occupancy_version = PackedInt32Array()
+	occupancy_version.resize(2)
+	occupancy_version[0] = 0
+	occupancy_version[1] = 0
 
 	var projectiles_by_tick = []
 	projectiles_by_tick.resize(input.time_limit_ticks + 1)
@@ -100,8 +241,13 @@ static func resolve(input) -> Dictionary:
 
 	while tick <= max_tick:
 		ticks_elapsed = tick
+		if profile_enabled:
+			profile_ticks += 1
 		var activity = false
 
+		var segment_start = 0
+		if profile_enabled:
+			segment_start = Time.get_ticks_usec()
 		var impacts = []
 		if tick < projectiles_by_tick.size():
 			impacts = projectiles_by_tick[tick]
@@ -138,6 +284,7 @@ static func resolve(input) -> Dictionary:
 							unit_y,
 							alive,
 							units_remaining,
+							occupancy_version,
 							tile_side,
 							tile_unit_count,
 							tile_total_size,
@@ -164,6 +311,7 @@ static func resolve(input) -> Dictionary:
 								unit_y,
 								alive,
 								units_remaining,
+								occupancy_version,
 								tile_side,
 								tile_unit_count,
 								tile_total_size,
@@ -176,6 +324,8 @@ static func resolve(input) -> Dictionary:
 			in_flight_projectiles -= 1
 			if in_flight_projectiles < 0:
 				in_flight_projectiles = 0
+		if profile_enabled:
+			time_impacts_usec += Time.get_ticks_usec() - segment_start
 
 		if units_remaining[BattleConstants.Side.RED] == 0 or units_remaining[BattleConstants.Side.BLUE] == 0:
 			post_battle = true
@@ -186,60 +336,150 @@ static func resolve(input) -> Dictionary:
 			tick += 1
 			continue
 
-		var dist_red_size2 = _compute_distance_field(
-			width,
-			height,
-			BattleConstants.Side.RED,
-			2,
-			tile_side,
-			tile_unit_count,
-			tile_total_size,
-			input.max_units_per_tile,
-			input.max_total_size_per_tile,
-			neighbors
-		)
-		var dist_red_size3 = _compute_distance_field(
-			width,
-			height,
-			BattleConstants.Side.RED,
-			3,
-			tile_side,
-			tile_unit_count,
-			tile_total_size,
-			input.max_units_per_tile,
-			input.max_total_size_per_tile,
-			neighbors
-		)
-		var dist_blue_size2 = _compute_distance_field(
-			width,
-			height,
-			BattleConstants.Side.BLUE,
-			2,
-			tile_side,
-			tile_unit_count,
-			tile_total_size,
-			input.max_units_per_tile,
-			input.max_total_size_per_tile,
-			neighbors
-		)
-		var dist_blue_size3 = _compute_distance_field(
-			width,
-			height,
-			BattleConstants.Side.BLUE,
-			3,
-			tile_side,
-			tile_unit_count,
-			tile_total_size,
-			input.max_units_per_tile,
-			input.max_total_size_per_tile,
-			neighbors
-		)
+		var field_needed = []
+		field_needed.resize(2)
+		for side_value in range(2):
+			var needs = PackedInt32Array()
+			needs.resize(max_unit_size + 1)
+			for size_value in range(max_unit_size + 1):
+				needs[size_value] = 0
+			field_needed[side_value] = needs
 
 		for id in range(unit_count):
 			if alive[id] == 0:
 				continue
 			if next_tick[id] > tick:
 				continue
+			var size_value = unit_size[id]
+			if size_value <= max_unit_size:
+				field_needed[side[id]][size_value] = 1
+
+		for s in range(squad_count):
+			if squad_anchor_x[s] < 0 or squad_anchor_y[s] < 0:
+				continue
+			if tick < squad_anchor_next_tick[s]:
+				continue
+			var side_value = squad_sides[s] if s < squad_sides.size() else BattleConstants.Side.RED
+			var size_value = squad_size_profile[s]
+			if size_value <= max_unit_size:
+				field_needed[side_value][size_value] = 1
+
+		if profile_enabled:
+			segment_start = Time.get_ticks_usec()
+		for side_value in range(2):
+			for size_value in range(max_unit_size + 1):
+				if field_needed[side_value][size_value] == 0:
+					continue
+				_ensure_distance_field(
+					field_cache[side_value][size_value],
+					side_value,
+					size_value,
+					tick,
+					width,
+					height,
+					tile_side,
+					neighbors,
+					terrain_version,
+					occupancy_version,
+					USE_UNIFORM_COST_BFS
+				)
+		if profile_enabled:
+			time_field_build_usec += Time.get_ticks_usec() - segment_start
+
+		if profile_enabled:
+			segment_start = Time.get_ticks_usec()
+		var squad_slack = PackedInt32Array()
+		squad_slack.resize(squad_count)
+		for s in range(squad_count):
+			var slack = squad_slack_base[s] + (squad_choke_active[s] * squad_slack_bonus[s])
+			squad_slack[s] = slack
+			if squad_anchor_x[s] >= 0 and squad_anchor_y[s] >= 0 and tick >= squad_anchor_next_tick[s]:
+				var side_value = squad_sides[s] if s < squad_sides.size() else BattleConstants.Side.RED
+				var size_profile = squad_size_profile[s]
+				var dist_field = field_cache[side_value][size_profile].dist
+				var current_tile = squad_anchor_x[s] + squad_anchor_y[s] * width
+				var current_dist = dist_field[current_tile]
+				var best_tile = current_tile
+				var best_dist = current_dist
+				var best_dir = squad_facing[s]
+				var dir_index = 0
+				for dir in BattleConstants.NEIGHBOR_DIRS:
+					var nx = squad_anchor_x[s] + dir.x
+					var ny = squad_anchor_y[s] + dir.y
+					if nx < 0 or nx >= width or ny < 0 or ny >= height:
+						dir_index += 1
+						continue
+					var tile = nx + ny * width
+					var dist = dist_field[tile]
+					if dist < best_dist:
+						best_dist = dist
+						best_tile = tile
+						best_dir = dir_index
+					dir_index += 1
+				if best_dist < current_dist and best_tile != current_tile:
+					squad_anchor_x[s] = best_tile % width
+					squad_anchor_y[s] = best_tile / width
+					squad_facing[s] = best_dir
+				squad_anchor_next_tick[s] += squad_anchor_delay[s]
+			if squad_anchor_x[s] >= 0 and squad_anchor_y[s] >= 0:
+				var anchor_pos = BattleConstants.encode_pos(squad_anchor_x[s], squad_anchor_y[s])
+				var packed = (squad_facing[s] << 16) | (slack & 0xFFFF)
+				var packed2 = (squad_anchor_delay[s] & 0xFFFF) | ((squad_choke_active[s] & 1) << 16)
+				event_log.add_event(
+					tick,
+					squad_ids[s],
+					BattleConstants.EventType.SQUAD_DEBUG,
+					squad_ids[s],
+					anchor_pos,
+					packed,
+					packed2
+				)
+		if profile_enabled:
+			time_anchor_usec += Time.get_ticks_usec() - segment_start
+
+		if profile_enabled:
+			segment_start = Time.get_ticks_usec()
+		var unit_rank = PackedInt32Array()
+		unit_rank.resize(unit_count)
+		for i in range(unit_count):
+			var s_index = unit_squad_index[i]
+			if s_index == -1:
+				unit_rank[i] = 0
+				continue
+			var offset = _rotate_offset(Vector2i(unit_slot_dx[i], unit_slot_dy[i]), squad_facing[s_index])
+			var dir = _dir_vector(squad_facing[s_index])
+			var projection = (offset.x * dir.x) + (offset.y * dir.y)
+			unit_rank[i] = -projection
+
+		var intent_tile = PackedInt32Array()
+		var best_tile = PackedInt32Array()
+		var origin_tile = PackedInt32Array()
+		var active_move = PackedInt32Array()
+		var active_attached = PackedInt32Array()
+		var moved_flag = PackedInt32Array()
+		intent_tile.resize(unit_count)
+		best_tile.resize(unit_count)
+		origin_tile.resize(unit_count)
+		active_move.resize(unit_count)
+		active_attached.resize(unit_count)
+		moved_flag.resize(unit_count)
+		for i in range(unit_count):
+			intent_tile[i] = -1
+			best_tile[i] = -1
+			origin_tile[i] = -1
+			active_move[i] = 0
+			active_attached[i] = 0
+			moved_flag[i] = 0
+
+		var move_units = []
+
+		for id in range(unit_count):
+			if alive[id] == 0:
+				continue
+			if next_tick[id] > tick:
+				continue
+			if profile_enabled:
+				profile_active_units += 1
 
 			var u_type = unit_type[id]
 			var u_side = side[id]
@@ -249,7 +489,24 @@ static func resolve(input) -> Dictionary:
 
 			var current_tile = ux + uy * width
 			var target_tile = _find_adjacent_enemy(current_tile, enemy_side, tile_side, neighbors)
+			var engaged = target_tile != -1
 			var acted = false
+			var formation_active = false
+			var desired_x = ux
+			var desired_y = uy
+			var squad_index = unit_squad_index[id]
+			if squad_index != -1 and squad_formation_enabled[squad_index] == 1:
+				if squad_anchor_x[squad_index] >= 0 and squad_anchor_y[squad_index] >= 0:
+					var offset = _rotate_offset(Vector2i(unit_slot_dx[id], unit_slot_dy[id]), squad_facing[squad_index])
+					desired_x = squad_anchor_x[squad_index] + offset.x
+					desired_y = squad_anchor_y[squad_index] + offset.y
+					var err = abs(ux - desired_x) + abs(uy - desired_y)
+					if err > DETACH_DIST:
+						unit_attached[id] = 0
+					elif unit_attached[id] == 0 and err <= REATTACH_DIST:
+						unit_attached[id] = 1
+					if unit_attached[id] == 1 and (unit_keep_formation_in_melee[id] == 1 or not engaged):
+						formation_active = true
 
 			if _is_melee_unit(u_type) and target_tile != -1:
 				var hit_roll = rng.next_range(100)
@@ -281,6 +538,7 @@ static func resolve(input) -> Dictionary:
 							unit_y,
 							alive,
 							units_remaining,
+							occupancy_version,
 							tile_side,
 							tile_unit_count,
 							tile_total_size,
@@ -289,6 +547,7 @@ static func resolve(input) -> Dictionary:
 						)
 						activity = true
 				acted = true
+				unit_no_progress[id] = 0
 				next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
 				continue
 
@@ -329,6 +588,7 @@ static func resolve(input) -> Dictionary:
 					)
 					activity = true
 					acted = true
+					unit_no_progress[id] = 0
 					next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
 					continue
 
@@ -369,17 +629,14 @@ static func resolve(input) -> Dictionary:
 					)
 					activity = true
 					acted = true
+					unit_no_progress[id] = 0
 					next_tick[id] = tick + BattleConstants.ATTACK_COST[u_type]
 					continue
 
 			if not acted:
-				var dist_field = dist_red_size2
-				if u_side == BattleConstants.Side.RED:
-					dist_field = dist_red_size3 if unit_size[id] == 3 else dist_red_size2
-				else:
-					dist_field = dist_blue_size3 if unit_size[id] == 3 else dist_blue_size2
-
-				var best_tile = _choose_move_tile(
+				var dist_field = field_cache[u_side][unit_size[id]].dist
+				var slack = squad_slack[squad_index] if formation_active else 0
+				var result = _choose_move_with_formation(
 					current_tile,
 					u_side,
 					unit_size[id],
@@ -389,16 +646,50 @@ static func resolve(input) -> Dictionary:
 					tile_total_size,
 					input.max_units_per_tile,
 					input.max_total_size_per_tile,
-					neighbors
+					width,
+					height,
+					desired_x,
+					desired_y,
+					formation_active,
+					slack
 				)
-				if best_tile != -1:
-					var from_pos = BattleConstants.encode_pos(ux, uy)
-					var new_x = best_tile % width
-					var new_y = best_tile / width
-					_remove_unit_from_tile(current_tile, id, unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
-					_add_unit_to_tile(best_tile, id, u_side, unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+				var chosen_tile = result["chosen"]
+				var best_goal_tile = result["best"]
+				if chosen_tile < 0:
+					chosen_tile = current_tile
+				intent_tile[id] = chosen_tile
+				best_tile[id] = best_goal_tile
+				origin_tile[id] = current_tile
+				active_move[id] = 1
+				if formation_active:
+					active_attached[id] = 1
+				if chosen_tile != current_tile:
+					move_units.append(id)
+
+		if profile_enabled:
+			time_unit_phase_usec += Time.get_ticks_usec() - segment_start
+			profile_move_units += move_units.size()
+
+		if move_units.size() > 0:
+			if profile_enabled:
+				segment_start = Time.get_ticks_usec()
+			var sorter = IntentSorter.new(unit_squad_index, unit_squad_id, unit_rank)
+			move_units.sort_custom(Callable(sorter, "less"))
+			for id in move_units:
+				var target = intent_tile[id]
+				if target == -1:
+					continue
+				if _tile_can_accept(target, side[id], unit_size[id], tile_side, tile_unit_count, tile_total_size, input.max_units_per_tile, input.max_total_size_per_tile):
+					var from_tile = origin_tile[id]
+					var from_pos = BattleConstants.encode_pos(from_tile % width, int(from_tile / width))
+					_remove_unit_from_tile(from_tile, id, unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+					_add_unit_to_tile(target, id, side[id], unit_size[id], tile_side, tile_unit_count, tile_total_size, tile_units)
+					var new_x = target % width
+					var new_y = target / width
 					unit_x[id] = new_x
 					unit_y[id] = new_y
+					occupancy_version[side[id]] += 1
+					moved_flag[id] = 1
 					event_log.add_event(
 						tick,
 						id,
@@ -409,9 +700,54 @@ static func resolve(input) -> Dictionary:
 						0
 					)
 					activity = true
-					next_tick[id] = tick + BattleConstants.MOVE_COST[u_type]
+			if profile_enabled:
+				time_move_apply_usec += Time.get_ticks_usec() - segment_start
+
+		if active_move.size() > 0:
+			for id in range(unit_count):
+				if active_move[id] == 0:
+					continue
+				if moved_flag[id] == 1:
+					next_tick[id] = tick + BattleConstants.MOVE_COST[unit_type[id]]
 				else:
-					next_tick[id] = tick + BattleConstants.WAIT_COST[u_type]
+					next_tick[id] = tick + BattleConstants.WAIT_COST[unit_type[id]]
+
+			for id in range(unit_count):
+				if active_move[id] == 0:
+					continue
+				if best_tile[id] == origin_tile[id]:
+					unit_no_progress[id] += 1
+					if unit_no_progress[id] >= STALE_GUARD_THRESHOLD:
+						var size_value = unit_size[id]
+						field_cache[side[id]][size_value].force_rebuild = true
+				else:
+					unit_no_progress[id] = 0
+
+		if profile_enabled:
+			segment_start = Time.get_ticks_usec()
+		var blocked_count = PackedInt32Array()
+		var attached_count = PackedInt32Array()
+		blocked_count.resize(squad_count)
+		attached_count.resize(squad_count)
+		for s in range(squad_count):
+			blocked_count[s] = 0
+			attached_count[s] = 0
+		for id in range(unit_count):
+			if active_attached[id] == 0:
+				continue
+			var s_index = unit_squad_index[id]
+			if s_index == -1:
+				continue
+			attached_count[s_index] += 1
+			if moved_flag[id] == 0 and best_tile[id] != origin_tile[id]:
+				blocked_count[s_index] += 1
+		for s in range(squad_count):
+			if attached_count[s] > 0 and blocked_count[s] * 2 >= attached_count[s]:
+				squad_choke_active[s] = 1
+			else:
+				squad_choke_active[s] = 0
+		if profile_enabled:
+			time_blocked_usec += Time.get_ticks_usec() - segment_start
 
 		if units_remaining[BattleConstants.Side.RED] == 0 or units_remaining[BattleConstants.Side.BLUE] == 0:
 			post_battle = true
@@ -468,10 +804,49 @@ static func resolve(input) -> Dictionary:
 	result.event_count = event_log.count()
 	result.event_hash = event_log.hash_u32()
 
+	if profile_enabled:
+		var total_usec = Time.get_ticks_usec() - profile_start_usec
+		var total_ms = float(total_usec) / 1000.0
+		var tick_div = max(profile_ticks, 1)
+		var active_avg = float(profile_active_units) / float(tick_div)
+		var move_avg = float(profile_move_units) / float(tick_div)
+		print("Profile ticks: %d" % profile_ticks)
+		print("Profile active units/tick: %.1f" % active_avg)
+		print("Profile move intents/tick: %.1f" % move_avg)
+		print("Profile field cadence: interval %d max_stale %d stale_guard %d" % [REBUILD_INTERVAL_TICKS, MAX_STALE_TICKS, STALE_GUARD_THRESHOLD])
+		var build_total = 0
+		var build_time_total = 0
+		for side_value in range(2):
+			for size_value in range(max_unit_size + 1):
+				var cache: FieldCache = field_cache[side_value][size_value]
+				if cache.build_count > 0:
+					var avg_ms = float(cache.build_time_usec) / 1000.0 / float(cache.build_count)
+					print("Profile field builds: side %d size %d count %d avg %.2f ms" % [side_value, size_value, cache.build_count, avg_ms])
+				build_total += cache.build_count
+				build_time_total += cache.build_time_usec
+		if build_total > 0:
+			var avg_total = float(build_time_total) / 1000.0 / float(build_total)
+			print("Profile field builds total: %d avg %.2f ms" % [build_total, avg_total])
+		if total_usec > 0:
+			print("Profile impacts: %.2f ms (%.1f%%)" % [float(time_impacts_usec) / 1000.0, float(time_impacts_usec) * 100.0 / float(total_usec)])
+			print("Profile field builds: %.2f ms (%.1f%%)" % [float(time_field_build_usec) / 1000.0, float(time_field_build_usec) * 100.0 / float(total_usec)])
+			print("Profile anchors: %.2f ms (%.1f%%)" % [float(time_anchor_usec) / 1000.0, float(time_anchor_usec) * 100.0 / float(total_usec)])
+			print("Profile unit phase: %.2f ms (%.1f%%)" % [float(time_unit_phase_usec) / 1000.0, float(time_unit_phase_usec) * 100.0 / float(total_usec)])
+			print("Profile move apply: %.2f ms (%.1f%%)" % [float(time_move_apply_usec) / 1000.0, float(time_move_apply_usec) * 100.0 / float(total_usec)])
+			print("Profile choke eval: %.2f ms (%.1f%%)" % [float(time_blocked_usec) / 1000.0, float(time_blocked_usec) * 100.0 / float(total_usec)])
+		print("Profile total: %.2f ms" % total_ms)
+
 	return {
 		"event_log": event_log,
 		"result": result,
 	}
+
+static func _max_unit_size(unit_size: PackedInt32Array) -> int:
+	var max_size = 0
+	for value in unit_size:
+		if value > max_size:
+			max_size = value
+	return max_size
 
 static func _build_neighbors(width: int, height: int) -> Array:
 	var neighbors = []
@@ -486,6 +861,39 @@ static func _build_neighbors(width: int, height: int) -> Array:
 					list.append(nx + ny * width)
 			neighbors[x + y * width] = list
 	return neighbors
+
+static func _median_move_delay(unit_ids: Array, unit_type: PackedInt32Array) -> int:
+	if unit_ids.is_empty():
+		return 1
+	var delays = []
+	for id in unit_ids:
+		delays.append(BattleConstants.MOVE_COST[unit_type[id]])
+	delays.sort()
+	return delays[int(delays.size() / 2)]
+
+static func _dir_vector(dir: int) -> Vector2i:
+	match dir:
+		BattleConstants.Dir.NORTH:
+			return Vector2i(0, -1)
+		BattleConstants.Dir.EAST:
+			return Vector2i(1, 0)
+		BattleConstants.Dir.SOUTH:
+			return Vector2i(0, 1)
+		BattleConstants.Dir.WEST:
+			return Vector2i(-1, 0)
+	return Vector2i.ZERO
+
+static func _rotate_offset(offset: Vector2i, facing: int) -> Vector2i:
+	match facing:
+		BattleConstants.Dir.NORTH:
+			return offset
+		BattleConstants.Dir.EAST:
+			return Vector2i(-offset.y, offset.x)
+		BattleConstants.Dir.SOUTH:
+			return Vector2i(-offset.x, -offset.y)
+		BattleConstants.Dir.WEST:
+			return Vector2i(offset.y, -offset.x)
+	return offset
 
 static func _is_melee_unit(u_type: int) -> bool:
 	return u_type == BattleConstants.UnitType.INFANTRY \
@@ -546,6 +954,94 @@ static func _tile_can_accept(
 		if tile_unit_count[tile] + 1 <= max_units and tile_total_size[tile] + unit_size <= max_total_size:
 			return true
 	return false
+
+static func _choose_move_with_formation(
+		current_tile: int,
+		unit_side: int,
+		unit_size: int,
+		dist_field: PackedInt32Array,
+		tile_side: PackedInt32Array,
+		tile_unit_count: PackedInt32Array,
+		tile_total_size: PackedInt32Array,
+		max_units: int,
+		max_total_size: int,
+		width: int,
+		height: int,
+		desired_x: int,
+		desired_y: int,
+		formation_active: bool,
+		slack: int
+	) -> Dictionary:
+	var candidates = []
+	var current_x = current_tile % width
+	var current_y = int(current_tile / width)
+	var stay_penalty = 0
+	if tile_side[current_tile] == unit_side:
+		stay_penalty = max(tile_unit_count[current_tile] - 1, 0) * FRIEND_PENALTY
+	var stay_cost = dist_field[current_tile] + stay_penalty
+	candidates.append({"tile": current_tile, "goal": stay_cost, "order": 0})
+	var best_cost = stay_cost
+	var best_tile = current_tile
+	var best_order = 0
+
+	var order = 1
+	for dir in BattleConstants.NEIGHBOR_DIRS:
+		var nx = current_x + dir.x
+		var ny = current_y + dir.y
+		if nx < 0 or nx >= width or ny < 0 or ny >= height:
+			order += 1
+			continue
+		var tile = nx + ny * width
+		if not _tile_can_accept(tile, unit_side, unit_size, tile_side, tile_unit_count, tile_total_size, max_units, max_total_size):
+			order += 1
+			continue
+		var dist = dist_field[tile]
+		if dist >= INF_DISTANCE:
+			order += 1
+			continue
+		var penalty = 0
+		if tile_side[tile] == unit_side:
+			penalty = tile_unit_count[tile] * FRIEND_PENALTY
+		var goal = dist + penalty
+		candidates.append({"tile": tile, "goal": goal, "order": order})
+		if goal < best_cost or (goal == best_cost and order < best_order):
+			best_cost = goal
+			best_tile = tile
+			best_order = order
+		order += 1
+
+	var limit = best_cost + slack
+	var chosen_tile = current_tile
+	var chosen_goal = stay_cost
+	var chosen_form = INF_DISTANCE
+	var chosen_order = 0
+	var found = false
+	for entry in candidates:
+		var goal = entry["goal"]
+		if goal > limit:
+			continue
+		var tile = entry["tile"]
+		if formation_active:
+			var tx = tile % width
+			var ty = int(tile / width)
+			var form = abs(tx - desired_x) + abs(ty - desired_y)
+			if not found or form < chosen_form or (form == chosen_form and (goal < chosen_goal or (goal == chosen_goal and entry["order"] < chosen_order))):
+				chosen_tile = tile
+				chosen_goal = goal
+				chosen_form = form
+				chosen_order = entry["order"]
+				found = true
+		else:
+			if not found or goal < chosen_goal or (goal == chosen_goal and entry["order"] < chosen_order):
+				chosen_tile = tile
+				chosen_goal = goal
+				chosen_order = entry["order"]
+				found = true
+
+	return {
+		"chosen": chosen_tile,
+		"best": best_tile,
+	}
 
 static func _find_adjacent_enemy(
 		tile: int,
@@ -619,24 +1115,111 @@ static func _find_best_fireball_tile(
 					best_count = count
 	return best_tile
 
-static func _compute_distance_field(
+static func _ensure_distance_field(
+		cache: FieldCache,
+		unit_side: int,
+		unit_size: int,
+		tick: int,
+		width: int,
+		height: int,
+		tile_side: PackedInt32Array,
+		neighbors: Array,
+		terrain_version: int,
+		occupancy_version: PackedInt32Array,
+		use_uniform_cost: bool
+	) -> void:
+	var enemy_side = BattleConstants.enemy_side(unit_side)
+	var dirty = false
+	if not cache.initialized:
+		dirty = true
+	if cache.built_terrain_version != terrain_version:
+		dirty = true
+	if cache.built_enemy_occupancy_version != occupancy_version[enemy_side]:
+		dirty = true
+	if cache.force_rebuild:
+		dirty = true
+
+	var should_rebuild = false
+	if not cache.initialized:
+		should_rebuild = true
+	elif tick - cache.last_build_tick >= MAX_STALE_TICKS:
+		should_rebuild = true
+	elif dirty and tick - cache.last_build_tick >= REBUILD_INTERVAL_TICKS:
+		should_rebuild = true
+
+	if not should_rebuild:
+		return
+
+	var start_usec = Time.get_ticks_usec()
+	_build_distance_field(cache.dist, width, height, unit_side, unit_size, tile_side, neighbors, use_uniform_cost)
+	var elapsed = Time.get_ticks_usec() - start_usec
+
+	cache.initialized = true
+	cache.last_build_tick = tick
+	cache.built_terrain_version = terrain_version
+	cache.built_enemy_occupancy_version = occupancy_version[enemy_side]
+	cache.force_rebuild = false
+	cache.build_count += 1
+	cache.build_time_usec += elapsed
+
+static func _build_distance_field(
+		dist: PackedInt32Array,
 		width: int,
 		height: int,
 		unit_side: int,
 		unit_size: int,
 		tile_side: PackedInt32Array,
-		tile_unit_count: PackedInt32Array,
-		tile_total_size: PackedInt32Array,
-		max_units: int,
-		max_total_size: int,
-		neighbors: Array
-	) -> PackedInt32Array:
+		neighbors: Array,
+		use_uniform_cost: bool
+	) -> void:
 	var tile_count = width * height
-	var dist = PackedInt32Array()
-	dist.resize(tile_count)
-	for i in range(tile_count):
-		dist[i] = INF_DISTANCE
+	if dist.size() != tile_count:
+		dist.resize(tile_count)
+	dist.fill(INF_DISTANCE)
+	if use_uniform_cost:
+		_build_distance_field_bfs(dist, width, height, unit_side, tile_side, neighbors)
+	else:
+		_build_distance_field_dijkstra(dist, width, height, unit_side, tile_side, neighbors)
 
+static func _build_distance_field_bfs(
+		dist: PackedInt32Array,
+		width: int,
+		height: int,
+		unit_side: int,
+		tile_side: PackedInt32Array,
+		neighbors: Array
+	) -> void:
+	var tile_count = width * height
+	var queue = PackedInt32Array()
+	queue.resize(tile_count)
+	var head = 0
+	var tail = 0
+	for tile in range(tile_count):
+		if tile_side[tile] != -1 and tile_side[tile] != unit_side:
+			dist[tile] = 0
+			queue[tail] = tile
+			tail += 1
+
+	while head < tail:
+		var tile = queue[head]
+		head += 1
+		var base_dist = dist[tile]
+		var next_dist = base_dist + BASE_STEP_COST
+		for neighbor in neighbors[tile]:
+			if next_dist < dist[neighbor]:
+				dist[neighbor] = next_dist
+				queue[tail] = neighbor
+				tail += 1
+
+static func _build_distance_field_dijkstra(
+		dist: PackedInt32Array,
+		width: int,
+		height: int,
+		unit_side: int,
+		tile_side: PackedInt32Array,
+		neighbors: Array
+	) -> void:
+	var tile_count = width * height
 	var heap_nodes = PackedInt32Array()
 	var heap_dists = PackedInt32Array()
 	for tile in range(tile_count):
@@ -651,17 +1234,10 @@ static func _compute_distance_field(
 		if base_dist != dist[tile]:
 			continue
 		for neighbor in neighbors[tile]:
-			var side_value = tile_side[neighbor]
-			if side_value != -1 and side_value != unit_side:
-				continue
-			var step_cost = SOFT_COST_EMPTY
-			if side_value == unit_side:
-				step_cost = SOFT_COST_EMPTY + (tile_unit_count[neighbor] * SOFT_COST_FRIENDLY_PER_UNIT)
-			var next_dist = base_dist + step_cost
+			var next_dist = base_dist + BASE_STEP_COST
 			if next_dist < dist[neighbor]:
 				dist[neighbor] = next_dist
 				_heap_push(heap_nodes, heap_dists, neighbor, next_dist)
-	return dist
 
 static func _heap_push(nodes: PackedInt32Array, dists: PackedInt32Array, node: int, dist: int) -> void:
 	nodes.append(node)
@@ -669,7 +1245,7 @@ static func _heap_push(nodes: PackedInt32Array, dists: PackedInt32Array, node: i
 	var index = nodes.size() - 1
 	while index > 0:
 		var parent = (index - 1) / 2
-		if dists[parent] <= dist:
+		if _heap_less(dists[parent], nodes[parent], dist, node):
 			break
 		nodes[index] = nodes[parent]
 		dists[index] = dists[parent]
@@ -700,9 +1276,9 @@ static func _heap_sift_down(nodes: PackedInt32Array, dists: PackedInt32Array, in
 			break
 		var right = left + 1
 		var smallest = left
-		if right < size and dists[right] < dists[left]:
+		if right < size and _heap_less(dists[right], nodes[right], dists[left], nodes[left]):
 			smallest = right
-		if dists[index] <= dists[smallest]:
+		if _heap_less(dists[index], nodes[index], dists[smallest], nodes[smallest]):
 			break
 		var tmp_node = nodes[index]
 		var tmp_dist = dists[index]
@@ -712,27 +1288,10 @@ static func _heap_sift_down(nodes: PackedInt32Array, dists: PackedInt32Array, in
 		dists[smallest] = tmp_dist
 		index = smallest
 
-static func _choose_move_tile(
-		current_tile: int,
-		unit_side: int,
-		unit_size: int,
-		dist_field: PackedInt32Array,
-		tile_side: PackedInt32Array,
-		tile_unit_count: PackedInt32Array,
-		tile_total_size: PackedInt32Array,
-		max_units: int,
-		max_total_size: int,
-		neighbors: Array
-	) -> int:
-	var best_tile = -1
-	var best_dist = INF_DISTANCE
-	var current_dist = dist_field[current_tile]
-	for neighbor in neighbors[current_tile]:
-		var dist = dist_field[neighbor]
-		if dist < best_dist and dist < current_dist and _tile_can_accept(neighbor, unit_side, unit_size, tile_side, tile_unit_count, tile_total_size, max_units, max_total_size):
-			best_dist = dist
-			best_tile = neighbor
-	return best_tile
+static func _heap_less(dist_a: int, node_a: int, dist_b: int, node_b: int) -> bool:
+	if dist_a == dist_b:
+		return node_a <= node_b
+	return dist_a < dist_b
 
 static func _schedule_projectile(
 		pid: int,
@@ -789,6 +1348,7 @@ static func _remove_unit(
 		unit_y: PackedInt32Array,
 		alive: PackedInt32Array,
 		units_remaining: PackedInt32Array,
+		occupancy_version: PackedInt32Array,
 		tile_side: PackedInt32Array,
 		tile_unit_count: PackedInt32Array,
 		tile_total_size: PackedInt32Array,
@@ -799,6 +1359,7 @@ static func _remove_unit(
 		return
 	alive[unit_id] = 0
 	units_remaining[side[unit_id]] -= 1
+	occupancy_version[side[unit_id]] += 1
 	var tile_index = unit_x[unit_id] + unit_y[unit_id] * width
 	_remove_unit_from_tile(tile_index, unit_id, unit_size[unit_id], tile_side, tile_unit_count, tile_total_size, tile_units)
 	event_log.add_event(
@@ -810,3 +1371,41 @@ static func _remove_unit(
 		source_id,
 		BattleConstants.encode_pos(unit_x[unit_id], unit_y[unit_id])
 	)
+
+class IntentSorter:
+	var unit_squad_index: PackedInt32Array
+	var unit_squad_id: PackedInt32Array
+	var unit_rank: PackedInt32Array
+
+	func _init(unit_squad_index_in: PackedInt32Array, unit_squad_id_in: PackedInt32Array, unit_rank_in: PackedInt32Array) -> void:
+		unit_squad_index = unit_squad_index_in
+		unit_squad_id = unit_squad_id_in
+		unit_rank = unit_rank_in
+
+	func less(a: int, b: int) -> bool:
+		var squad_a = unit_squad_index[a]
+		var squad_b = unit_squad_index[b]
+		var has_a = squad_a != -1
+		var has_b = squad_b != -1
+		if has_a != has_b:
+			return has_a
+		if has_a:
+			var id_a = unit_squad_id[a]
+			var id_b = unit_squad_id[b]
+			if id_a != id_b:
+				return id_a < id_b
+			var rank_a = unit_rank[a]
+			var rank_b = unit_rank[b]
+			if rank_a != rank_b:
+				return rank_a < rank_b
+		return a < b
+
+class FieldCache:
+	var dist = PackedInt32Array()
+	var initialized: bool = false
+	var last_build_tick: int = -MAX_STALE_TICKS
+	var built_terrain_version: int = -1
+	var built_enemy_occupancy_version: int = -1
+	var force_rebuild: bool = false
+	var build_count: int = 0
+	var build_time_usec: int = 0

--- a/run.ps1
+++ b/run.ps1
@@ -30,7 +30,14 @@ if (!(Test-Path $GodotBin)) {
   exit 1
 }
 
-& $GodotBin --path $ScriptDir @args
+$resolveOnly = $args -contains "--resolve-only"
+$headless = $args -contains "--headless"
+$extraArgs = @()
+if ($resolveOnly -and -not $headless) {
+  $extraArgs += "--headless"
+}
+
+& $GodotBin --path $ScriptDir @extraArgs @args
 $exitCode = $LASTEXITCODE
 if ($exitCode -ne 0) {
   exit $exitCode

--- a/run.sh
+++ b/run.sh
@@ -33,4 +33,19 @@ if [[ "$UNAME" != MINGW* && "$UNAME" != MSYS* && "$UNAME" != CYGWIN* ]]; then
   fi
 fi
 
-exec "$GODOT_BIN" --path "$SCRIPT_DIR" "$@"
+resolve_only=0
+headless=0
+for arg in "$@"; do
+  if [[ "$arg" == "--resolve-only" ]]; then
+    resolve_only=1
+  elif [[ "$arg" == "--headless" ]]; then
+    headless=1
+  fi
+done
+
+extra_args=()
+if [[ $resolve_only -eq 1 && $headless -eq 0 ]]; then
+  extra_args+=(--headless)
+fi
+
+exec "$GODOT_BIN" --path "$SCRIPT_DIR" "${extra_args[@]}" "$@"

--- a/schema/battle_input.gd
+++ b/schema/battle_input.gd
@@ -16,6 +16,8 @@ var unit_x = PackedInt32Array()
 var unit_y = PackedInt32Array()
 var unit_next_tick = PackedInt32Array()
 var unit_squad_ids = PackedInt32Array()
+var unit_slot_dx = PackedInt32Array()
+var unit_slot_dy = PackedInt32Array()
 
 var squad_ids = PackedInt32Array()
 var squad_sides = PackedInt32Array()

--- a/schema/constants.gd
+++ b/schema/constants.gd
@@ -11,6 +11,13 @@ enum Facing {
 	RIGHT = 1,
 }
 
+enum Dir {
+	NORTH = 0,
+	EAST = 1,
+	SOUTH = 2,
+	WEST = 3,
+}
+
 enum UnitType {
 	INFANTRY = 0,
 	HEAVY_INFANTRY = 1,
@@ -30,6 +37,7 @@ enum EventType {
 	PROJECTILE_IMPACTED = 5,
 	UNIT_REMOVED = 6,
 	BATTLE_ENDED = 7,
+	SQUAD_DEBUG = 8,
 }
 
 enum ProjectileType {


### PR DESCRIPTION
## Summary
- Implement squad formation movement (anchors, goal-slack, detach/reattach, two-phase intents).
- Cache strategic distance fields per side/size with cadence + stale-guard rebuilds.
- Add uniform-cost BFS fast path and resolve profiling flag; auto-headless for `--resolve-only`.
- Update docs for formation movement scope and field rebuild cadence.

## Approach
- Field cache keyed by `(side, size)` with terrain/enemy-occupancy versions; rebuild only when dirty and past `REBUILD_INTERVAL_TICKS` (8), or when `MAX_STALE_TICKS` (32) is reached.
- Needed-mask ensures fields are only rebuilt when active movers/anchors require them.
- Stale guard (4 activations without goal improvement) forces a rebuild on the next eligible tick.
- BFS is used when all edge costs are uniform; Dijkstra remains the general path for future terrain weights.

## Results (headless profile)
Before (baseline):
- 64.1s resolve, ~14.2 tps
- 3636 field builds; Dijkstra time 56.0s (87%)

After (this PR):
- 8.9s resolve, ~102 tps
- 419 field builds; field build time 0.73s (8%)

## Testing
- `./run.sh --resolve-only --profile-resolve`
