### PR TITLE
Add terrain costs and tree visualization

### DIFF
--- a/docs/tick_battle_scale_prototype_base_requirements.md
+++ b/docs/tick_battle_scale_prototype_base_requirements.md
@@ -137,6 +137,16 @@ Move is 1 tile per action. Minimum cost is always ≥ 1 tick.
 | Heavy Cavalry    | 5 | 13 (melee) | 1 | heavier |
 | Mage             | 6 | 16 (fireball) | 1 | AoE |
 
+### Terrain Costs (v1)
+
+Terrain applies a movement multiplier to the base move cost:
+- Grassland: **1×**
+- Trees: **2×**
+
+Special case:
+- Cavalry (including Heavy Cavalry) **lose their speed advantage in trees** and use the Infantry base move cost before applying the 2× multiplier.
+- Terrain should be part of `BattleInput` and emitted in the event log at tick 0 so the replayer can render it.
+
 ### Melee Hit Chances
 
 Keep “one-hit removal,” but allow melee hit chance to vary by unit type:

--- a/docs/tick_battle_scale_prototype_godot45_requirements.md
+++ b/docs/tick_battle_scale_prototype_godot45_requirements.md
@@ -110,6 +110,14 @@ Required implementation shape:
  - Cache fields per `(side, size)` and rebuild on a cadence (dirty + `REBUILD_INTERVAL_TICKS`, or `MAX_STALE_TICKS` safety).
  - A BFS fast path is allowed when all edge costs are uniform.
 
+### Terrain Costs (v1)
+- Track `tile_terrain` in `BattleInput` and log `TERRAIN_SET` events at tick 0 for replay.
+- Terrain types:
+  - Grassland: cost **1**
+  - Trees: cost **2**
+- Movement delay = base move cost × terrain cost.
+- Cavalry (including Heavy Cavalry) use the Infantry base move cost on trees (no speed advantage).
+
 ---
 
 ## 8. Event Log Representation (Memory Matters)

--- a/docs/tick_battle_scale_prototype_squad_pathing_companion.md
+++ b/docs/tick_battle_scale_prototype_squad_pathing_companion.md
@@ -96,6 +96,12 @@ Optional (but helpful):
 
 - `terrain_type[tile] : int`
 - `terrain_version : int` (increment on spell changes)
+- Prototype v1 terrain types:
+  - Grassland = 0
+  - Trees = 1
+- Prototype v1 terrain costs:
+  - Grassland: 1
+  - Trees: 2
 
 ### 3.4 Occupancy index
 
@@ -141,6 +147,7 @@ Provide a function:
 Rules:
 - If `tile_to` is impassable for this (profile,size), it is not expanded.
 - Cost must be **integer** for determinism and easy slack tuning.
+- Prototype v1: `step_cost = TERRAIN_COST[terrain_type[tile_to]]` (grass=1, trees=2).
 
 Important: **Do not include friendly occupancy in this step cost.**
 
@@ -301,11 +308,13 @@ When a unit moves into `p`, set:
 - `next_tick[u] += move_delay(unit_type[u], terrain_type[p], status_effects[u])`
 
 Prototype: if statuses aren’t implemented yet, just use `terrain_type[p]` and unit base speed.
+For trees, cavalry types use the Infantry base move cost before applying the multiplier.
 
 Examples:
-- cavalry on open: 6
-- infantry on open: 10
-- cavalry in woods: 10 (advantage removed)
+- cavalry on open: 4
+- infantry on open: 6
+- cavalry in trees: 12 (advantage removed)
+- infantry in trees: 12
 - paralyzed: very large delay or “cannot move” flag (still can fight)
 
 ### 7.2 Why this avoids “rewrite tons of pathfinding code”

--- a/replayer/battle_replayer.gd
+++ b/replayer/battle_replayer.gd
@@ -25,6 +25,7 @@ var last_move_tick = PackedInt32Array()
 var last_attack_tick = PackedInt32Array()
 var units_remaining = PackedInt32Array([0, 0])
 var tile_unit_count = PackedInt32Array()
+var tile_terrain = PackedInt32Array()
 var tile_facing = PackedInt32Array()
 
 var squad_anchor_x = PackedInt32Array()
@@ -112,9 +113,11 @@ func _reset_state() -> void:
 
 	var tile_count = grid_width * grid_height
 	tile_unit_count.resize(tile_count)
+	tile_terrain.resize(tile_count)
 	tile_facing.resize(tile_count)
 	for i in range(tile_count):
 		tile_unit_count[i] = 0
+		tile_terrain[i] = BattleConstants.TerrainType.GRASS
 		tile_facing[i] = -1
 
 	squad_anchor_x.resize(squad_count)
@@ -208,6 +211,11 @@ func _apply_event(index: int) -> void:
 		BattleConstants.EventType.BATTLE_INIT:
 			grid_width = event_log.a[index]
 			grid_height = event_log.b[index]
+		BattleConstants.EventType.TERRAIN_SET:
+			var tile = event_log.a[index]
+			var terrain_type = event_log.b[index]
+			if tile >= 0 and tile < tile_terrain.size():
+				tile_terrain[tile] = terrain_type
 		BattleConstants.EventType.UNIT_SPAWNED:
 			var unit_id = event_log.a[index]
 			var side = event_log.b[index]

--- a/scenarios/scale_test_v1.gd
+++ b/scenarios/scale_test_v1.gd
@@ -44,7 +44,29 @@ static func _build_base_input(seed: int) -> BattleInput:
 	input.max_total_size_per_tile = MAX_TOTAL_SIZE_PER_TILE
 	input.seed = seed
 	input.time_limit_ticks = TIME_LIMIT_TICKS
+	input.tile_terrain = _build_terrain(GRID_WIDTH, GRID_HEIGHT)
 	return input
+
+static func _build_terrain(width: int, height: int) -> PackedInt32Array:
+	var terrain = PackedInt32Array()
+	terrain.resize(width * height)
+	for i in range(terrain.size()):
+		terrain[i] = BattleConstants.TerrainType.GRASS
+
+	_add_tree_patch(terrain, width, height, Rect2i(18, 6, 10, 6))
+	_add_tree_patch(terrain, width, height, Rect2i(34, 16, 12, 7))
+	_add_tree_patch(terrain, width, height, Rect2i(50, 24, 12, 7))
+
+	return terrain
+
+static func _add_tree_patch(terrain: PackedInt32Array, width: int, height: int, rect: Rect2i) -> void:
+	var x0 = clamp(rect.position.x, 0, width)
+	var y0 = clamp(rect.position.y, 0, height)
+	var x1 = clamp(rect.position.x + rect.size.x, 0, width)
+	var y1 = clamp(rect.position.y + rect.size.y, 0, height)
+	for y in range(y0, y1):
+		for x in range(x0, x1):
+			terrain[x + y * width] = BattleConstants.TerrainType.TREES
 
 static func _populate_side(input, side: int, zone_start: int, next_unit_id: int, next_squad_id: int) -> Dictionary:
 	var front_is_high = side == BattleConstants.Side.RED

--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -308,6 +308,18 @@ func _show_preview(input) -> void:
 		input.time_limit_ticks,
 		input.unit_count()
 	)
+	var tile_count = input.grid_width * input.grid_height
+	if input.tile_terrain.size() == tile_count:
+		for tile in range(tile_count):
+			log.add_event(
+				0,
+				0,
+				BattleConstants.EventType.TERRAIN_SET,
+				tile,
+				input.tile_terrain[tile],
+				0,
+				0
+			)
 	for i in range(input.unit_count()):
 		var unit_id = input.unit_ids[i]
 		log.add_event(

--- a/schema/battle_input.gd
+++ b/schema/battle_input.gd
@@ -19,6 +19,8 @@ var unit_squad_ids = PackedInt32Array()
 var unit_slot_dx = PackedInt32Array()
 var unit_slot_dy = PackedInt32Array()
 
+var tile_terrain = PackedInt32Array()
+
 var squad_ids = PackedInt32Array()
 var squad_sides = PackedInt32Array()
 var squad_formations = PackedInt32Array()

--- a/schema/constants.gd
+++ b/schema/constants.gd
@@ -28,6 +28,11 @@ enum UnitType {
 	MAGE = 6,
 }
 
+enum TerrainType {
+	GRASS = 0,
+	TREES = 1,
+}
+
 enum EventType {
 	BATTLE_INIT = 0,
 	UNIT_SPAWNED = 1,
@@ -38,6 +43,7 @@ enum EventType {
 	UNIT_REMOVED = 6,
 	BATTLE_ENDED = 7,
 	SQUAD_DEBUG = 8,
+	TERRAIN_SET = 9,
 }
 
 enum ProjectileType {
@@ -59,6 +65,7 @@ static var PROJECTILE_SPEED = PackedInt32Array([2, 3])
 static var DEFAULT_FACING = PackedInt32Array([Facing.RIGHT, Facing.LEFT])
 
 const MAX_SQUAD_SIZE = 50
+static var TERRAIN_COST = PackedInt32Array([1, 2])
 
 const NEIGHBOR_DIRS = [
 	Vector2i(0, -1),


### PR DESCRIPTION
## Summary
- add terrain types + costs (grass=1, trees=2) and log terrain to the event log
- apply terrain costs in fields and move timing; cavalry uses infantry base move cost in trees
- render tree tiles in replay/preview and keep terrain visible even when no units are present
- add sample tree patches to the scale test scenario
- document terrain costs and terrain logging across the design docs

## Testing
- ./run.sh --resolve-only